### PR TITLE
Certified producers logic

### DIFF
--- a/contracts/ProducerContract.sol
+++ b/contracts/ProducerContract.sol
@@ -183,6 +183,10 @@ contract ProducerContract is Callable {
   function setCertificate(address addr) public mustBeAllowedCaller returns (bool) {
     Producer memory producer = producers[addr];
 
+    if (producers[addr].syntropicProducer) {
+      return true;
+    }  
+
     if (producer.isa.isaScore < 0) return true;
 
     if (minimumInspections(producer.totalInspections)) {

--- a/contracts/ProducerContract.sol
+++ b/contracts/ProducerContract.sol
@@ -185,8 +185,10 @@ contract ProducerContract is Callable {
 
     if (producer.isa.isaScore < 0) return true;
 
-    if (minimumInspections(producer.totalInspections)) producers[addr].syntropicProducer = true;
-    if (minimumInspections(producer.totalInspections)) producers[addr].pool.currentEra = producerPool.currentContractEra();
+    if (minimumInspections(producer.totalInspections))
+      producers[addr].syntropicProducer = true;
+    if (minimumInspections(producer.totalInspections))
+      producers[addr].pool.currentEra = producerPool.currentContractEra();
 
     return true;
   }

--- a/contracts/ProducerContract.sol
+++ b/contracts/ProducerContract.sol
@@ -68,7 +68,8 @@ contract ProducerContract is Callable {
       0,
       Isa(0, 0, false),
       PropertyAddress(country, state, city, street, complement, cep),
-      Pool(producerPool.currentContractEra())
+      Pool(0),  //Pool(producerPool.currentContractEra()),
+      false
     );
 
     producers[msg.sender] = producer;
@@ -153,7 +154,7 @@ contract ProducerContract is Callable {
     if (producer.isa.sustainable) return true;
     if (newProducerScore < 0) isaScore = isaScore - (newProducerScore);
 
-    producersTotalScore += isaScore;
+    if(producer.certified = true) producersTotalScore += isaScore;
 
     if (limitIsaScore(producer.isa.isaScore)) changeProducerToSustainable(producer);
 
@@ -176,5 +177,13 @@ contract ProducerContract is Callable {
 
   function lastRequestAt(address addr, uint256 blocksNumber) public mustBeAllowedCaller {
     producers[addr].lastRequestAt = blocksNumber;
+  }
+
+  function setCertificate(address addr) public mustBeAllowedCaller {
+    Producer memory producer = producers[addr];
+    
+    if (minimumInspections(producer.totalInspections)) producers[addr].certified = true;
+    if (minimumInspections(producer.totalInspections)) producers[addr].pool.currentEra = producerPool.currentContractEra();
+
   }
 }

--- a/contracts/ProducerContract.sol
+++ b/contracts/ProducerContract.sol
@@ -68,7 +68,7 @@ contract ProducerContract is Callable {
       0,
       Isa(0, 0, false),
       PropertyAddress(country, state, city, street, complement, cep),
-      Pool(0),  //Pool(producerPool.currentContractEra()),
+      Pool(0), //Pool(producerPool.currentContractEra()),
       false
     );
 
@@ -154,7 +154,7 @@ contract ProducerContract is Callable {
     if (producer.isa.sustainable) return true;
     if (newProducerScore < 0) isaScore = isaScore - (newProducerScore);
 
-    if(producer.certified = true) producersTotalScore += isaScore;
+    if (producer.certified = true) producersTotalScore += isaScore;
 
     if (limitIsaScore(producer.isa.isaScore)) changeProducerToSustainable(producer);
 
@@ -181,9 +181,9 @@ contract ProducerContract is Callable {
 
   function setCertificate(address addr) public mustBeAllowedCaller {
     Producer memory producer = producers[addr];
-    
-    if (minimumInspections(producer.totalInspections)) producers[addr].certified = true;
-    if (minimumInspections(producer.totalInspections)) producers[addr].pool.currentEra = producerPool.currentContractEra();
 
+    if (minimumInspections(producer.totalInspections)) producers[addr].certified = true;
+    if (minimumInspections(producer.totalInspections))
+      producers[addr].pool.currentEra = producerPool.currentContractEra();
   }
 }

--- a/contracts/ProducerContract.sol
+++ b/contracts/ProducerContract.sol
@@ -183,7 +183,6 @@ contract ProducerContract is Callable {
     Producer memory producer = producers[addr];
 
     if (minimumInspections(producer.totalInspections)) producers[addr].certified = true;
-    if (minimumInspections(producer.totalInspections))
-      producers[addr].pool.currentEra = producerPool.currentContractEra();
+    if (minimumInspections(producer.totalInspections)) producers[addr].pool.currentEra = producerPool.currentContractEra();
   }
 }

--- a/contracts/ProducerContract.sol
+++ b/contracts/ProducerContract.sol
@@ -154,7 +154,7 @@ contract ProducerContract is Callable {
     if (producer.isa.sustainable) return true;
     if (newProducerScore < 0) isaScore = isaScore - (newProducerScore);
 
-    if (producer.certified) producersTotalScore += isaScore;
+    if (producer.syntropicProducer) producersTotalScore += isaScore;
 
     if (limitIsaScore(producer.isa.isaScore)) changeProducerToSustainable(producer);
 
@@ -185,7 +185,7 @@ contract ProducerContract is Callable {
 
     if (producer.isa.isaScore < 0) return true;
 
-    if (minimumInspections(producer.totalInspections)) producers[addr].certified = true;
+    if (minimumInspections(producer.totalInspections)) producers[addr].syntropicProducer = true;
     if (minimumInspections(producer.totalInspections)) producers[addr].pool.currentEra = producerPool.currentContractEra();
 
     return true;

--- a/contracts/ProducerContract.sol
+++ b/contracts/ProducerContract.sol
@@ -68,7 +68,7 @@ contract ProducerContract is Callable {
       0,
       Isa(0, 0, false),
       PropertyAddress(country, state, city, street, complement, cep),
-      Pool(0), //Pool(producerPool.currentContractEra()),
+      Pool(producerPool.currentContractEra()),
       false
     );
 
@@ -154,7 +154,7 @@ contract ProducerContract is Callable {
     if (producer.isa.sustainable) return true;
     if (newProducerScore < 0) isaScore = isaScore - (newProducerScore);
 
-    if (producer.certified = true) producersTotalScore += isaScore;
+    if (producer.certified) producersTotalScore += isaScore;
 
     if (limitIsaScore(producer.isa.isaScore)) changeProducerToSustainable(producer);
 
@@ -173,16 +173,21 @@ contract ProducerContract is Callable {
 
   function incrementInspections(address addr) public mustBeAllowedCaller {
     producers[addr].totalInspections++;
+    setCertificate(addr);
   }
 
   function lastRequestAt(address addr, uint256 blocksNumber) public mustBeAllowedCaller {
     producers[addr].lastRequestAt = blocksNumber;
   }
 
-  function setCertificate(address addr) public mustBeAllowedCaller {
+  function setCertificate(address addr) public mustBeAllowedCaller returns (bool) {
     Producer memory producer = producers[addr];
+
+    if (producer.isa.isaScore < 0) return true;
 
     if (minimumInspections(producer.totalInspections)) producers[addr].certified = true;
     if (minimumInspections(producer.totalInspections)) producers[addr].pool.currentEra = producerPool.currentContractEra();
+
+    return true;
   }
 }

--- a/contracts/ProducerContract.sol
+++ b/contracts/ProducerContract.sol
@@ -185,10 +185,10 @@ contract ProducerContract is Callable {
 
     if (producer.isa.isaScore < 0) return true;
 
-    if (minimumInspections(producer.totalInspections))
+    if (minimumInspections(producer.totalInspections)) {
       producers[addr].syntropicProducer = true;
-    if (minimumInspections(producer.totalInspections))
       producers[addr].pool.currentEra = producerPool.currentContractEra();
+    }
 
     return true;
   }

--- a/contracts/Sintrop.sol
+++ b/contracts/Sintrop.sol
@@ -137,6 +137,8 @@ contract Sintrop {
 
     afterRealizeInspection(inspection);
 
+    producerContract.setCertificate(inspection.createdBy);
+
     producerContract.setIsaScore(inspection.createdBy, inspection.isaScore);
 
     activistInspected[msg.sender][inspection.createdBy] = true;

--- a/contracts/Sintrop.sol
+++ b/contracts/Sintrop.sol
@@ -137,7 +137,7 @@ contract Sintrop {
 
     afterRealizeInspection(inspection);
 
-    producerContract.setCertificate(inspection.createdBy);
+    //producerContract.setCertificate(inspection.createdBy);
 
     producerContract.setIsaScore(inspection.createdBy, inspection.isaScore);
 

--- a/contracts/types/ProducerTypes.sol
+++ b/contracts/types/ProducerTypes.sol
@@ -16,7 +16,7 @@ struct Producer {
   Isa isa;
   PropertyAddress propertyAddress;
   Pool pool;
-  bool certified;
+  bool syntropicProducer;
 }
 
 struct Pool {

--- a/contracts/types/ProducerTypes.sol
+++ b/contracts/types/ProducerTypes.sol
@@ -16,6 +16,7 @@ struct Producer {
   Isa isa;
   PropertyAddress propertyAddress;
   Pool pool;
+  bool certified;
 }
 
 struct Pool {

--- a/test/ProducerContract.test.js
+++ b/test/ProducerContract.test.js
@@ -167,7 +167,7 @@ contract("ProducerContract", (accounts) => {
 
       const producer = await instance.getProducer(prod1Address);
 
-      assert.equal(producer.certified, false);
+      assert.equal(producer.syntropicProducer, false);
     });
   });
 
@@ -284,6 +284,9 @@ contract("ProducerContract", (accounts) => {
       context("when dont have producers sustainable", () => {
         context("when have 1 producer", () => {
           beforeEach(async () => {
+            await instance.incrementInspections(prod1Address);
+            await instance.incrementInspections(prod1Address);
+            await instance.incrementInspections(prod1Address);
             await instance.setIsaScore(prod1Address, 600);
           });
 
@@ -395,13 +398,26 @@ contract("ProducerContract", (accounts) => {
 
         context("when have more tha one producer", () => {
           beforeEach(async () => {
+            await instance.incrementInspections(prod1Address);
+            await instance.incrementInspections(prod1Address);
+            await instance.incrementInspections(prod1Address);
+
             await instance.setIsaScore(prod1Address, 600);
+
             await addProducer("Producer B", prod2Address);
+            await instance.incrementInspections(prod2Address);
+            await instance.incrementInspections(prod2Address);
+            await instance.incrementInspections(prod2Address);
+
             await instance.setIsaScore(prod2Address, 800);
           });
 
           context("when new score + producer A score is smaller than limit score", () => {
             beforeEach(async () => {
+              await instance.incrementInspections(prod1Address);
+              await instance.incrementInspections(prod1Address);
+              await instance.incrementInspections(prod1Address);
+
               await instance.setIsaScore(prod1Address, 70);
             });
 
@@ -426,6 +442,10 @@ contract("ProducerContract", (accounts) => {
 
           context("when new score + producer A score is equal than limit score", () => {
             beforeEach(async () => {
+              await instance.incrementInspections(prod1Address);
+              await instance.incrementInspections(prod1Address);
+              await instance.incrementInspections(prod1Address);
+
               await instance.setIsaScore(prod1Address, 400);
             });
 
@@ -456,6 +476,10 @@ contract("ProducerContract", (accounts) => {
 
           context("when new score + producer score result in a negative value", () => {
             beforeEach(async () => {
+              await instance.incrementInspections(prod1Address);
+              await instance.incrementInspections(prod1Address);
+              await instance.incrementInspections(prod1Address);
+
               await instance.setIsaScore(prod1Address, -610);
             });
 
@@ -483,6 +507,10 @@ contract("ProducerContract", (accounts) => {
       context("when have producers sustainable", () => {
         context("when have 1 producer", () => {
           beforeEach(async () => {
+            await instance.incrementInspections(prod1Address);
+            await instance.incrementInspections(prod1Address);
+            await instance.incrementInspections(prod1Address);
+
             await instance.setIsaScore(prod1Address, 1000);
           });
 
@@ -513,13 +541,24 @@ contract("ProducerContract", (accounts) => {
 
         context("when have more than one producer", () => {
           beforeEach(async () => {
+            await instance.incrementInspections(prod1Address);
+            await instance.incrementInspections(prod1Address);
+            await instance.incrementInspections(prod1Address);            
             await instance.setIsaScore(prod1Address, 1000);
+
             await addProducer("Producer B", prod2Address);
+            await instance.incrementInspections(prod2Address);
+            await instance.incrementInspections(prod2Address);
+            await instance.incrementInspections(prod2Address);
             await instance.setIsaScore(prod2Address, 800);
           });
 
           context("when producer A receive more 100 isa score", () => {
             beforeEach(async () => {
+              await instance.incrementInspections(prod1Address);
+              await instance.incrementInspections(prod1Address);
+              await instance.incrementInspections(prod1Address);
+
               await instance.setIsaScore(prod1Address, 100);
             });
 
@@ -538,6 +577,10 @@ contract("ProducerContract", (accounts) => {
 
           context("when producer B receive more 100 isa score", () => {
             beforeEach(async () => {
+              await instance.incrementInspections(prod2Address);
+              await instance.incrementInspections(prod2Address);
+              await instance.incrementInspections(prod2Address);
+
               await instance.setIsaScore(prod2Address, 100);
             });
 
@@ -688,6 +731,20 @@ contract("ProducerContract", (accounts) => {
     context("with not producer", () => {
       it("should return error message", async () => {
         await expectRevert(instance.withdraw(), "Only producers pool");
+      });
+    });
+  });
+
+  describe("#setCertificate", () => {
+    context("", () => {
+      beforeEach(async () => {
+
+      });
+
+      context("", () => {
+        it("", async () => {
+
+        });
       });
     });
   });

--- a/test/ProducerContract.test.js
+++ b/test/ProducerContract.test.js
@@ -94,7 +94,7 @@ contract("ProducerContract", (accounts) => {
       assert.equal(producer.isa.isaAverage, "0");
       assert.equal(producer.isa.isaScore, "0");
 
-      assert.equal(producer.pool.currentEra, 0);
+      assert.equal(producer.pool.currentEra, 1);
 
       assert.equal(producer.propertyAddress.country, "Brazil");
       assert.equal(producer.propertyAddress.state, "SP");

--- a/test/ProducerContract.test.js
+++ b/test/ProducerContract.test.js
@@ -639,6 +639,8 @@ contract("ProducerContract", (accounts) => {
                 await instance.setIsaScore(prod1Address, 50);
                 await instance.setIsaScore(prod2Address, 50);
 
+                await advanceBlock(producerPoolArgs.blocksPerEra);
+                await advanceBlock(producerPoolArgs.blocksPerEra);
                 await instance.withdraw({ from: prod1Address });
                 await instance.withdraw({ from: prod2Address });
               });
@@ -658,19 +660,20 @@ contract("ProducerContract", (accounts) => {
               it("producer A current era must be incremented", async () => {
                 const producer = await instance.getProducer(prod1Address);
 
-                assert.equal(producer.pool.currentEra, 1);
+                assert.equal(producer.pool.currentEra, 3);
               });
 
               it("producer B current era must be incremented", async () => {
                 const producer = await instance.getProducer(prod2Address);
 
-                assert.equal(producer.pool.currentEra, 1);
+                assert.equal(producer.pool.currentEra, 3);
               });
             });
 
             context("when producer have isaScore 100", () => {
               beforeEach(async () => {
                 await instance.setIsaScore(prod1Address, 100);
+                await advanceBlock(producerPoolArgs.blocksPerEra);
                 await instance.withdraw({ from: prod1Address });
               });
 
@@ -683,7 +686,7 @@ contract("ProducerContract", (accounts) => {
               it("producer current era must be increment", async () => {
                 const producer = await instance.getProducer(prod1Address);
 
-                assert.equal(producer.pool.currentEra, 1);
+                assert.equal(producer.pool.currentEra, 3);
               });
             });
 
@@ -736,14 +739,65 @@ contract("ProducerContract", (accounts) => {
   });
 
   describe("#setCertificate", () => {
-    context("", () => {
+    context("when isaScore > 0", () => {
       beforeEach(async () => {
-
+        await addProducer("Producer A", prod1Address);
+        await instance.incrementInspections(prod1Address);
+        await instance.setIsaScore(prod1Address, 100);
       });
 
-      context("", () => {
-        it("", async () => {
+      context("when received 1 inspection", () => {
+        it("syntropicProducer must be false", async () => {
+          const producer = await instance.getProducer(prod1Address);
+    
+          assert.equal(producer.syntropicProducer, false);
+        });
 
+        it("producer currentEra must be 1", async () => {
+          const producer = await instance.getProducer(prod1Address);
+
+          assert.equal(producer.pool.currentEra, 1);
+        });
+      });
+
+      context("when received 2 inspections", () => {
+        beforeEach(async () => {
+          await instance.incrementInspections(prod1Address);
+          await instance.setIsaScore(prod1Address, 100);
+        });
+
+        it("syntropicProducer must be false", async () => {
+          const producer = await instance.getProducer(prod1Address);
+
+          assert.equal(producer.syntropicProducer, false);
+        });
+
+        it("producer currentEra must be 1", async () => {
+          const producer = await instance.getProducer(prod1Address);
+
+          assert.equal(producer.pool.currentEra, 1);
+        });
+      });
+
+      context("when received 3 inspections", () => {
+        beforeEach(async () => {
+          await advanceBlock(producerPoolArgs.blocksPerEra);
+          await instance.incrementInspections(prod1Address);
+          await instance.setIsaScore(prod1Address, 100);
+          await instance.incrementInspections(prod1Address);
+          await instance.setIsaScore(prod1Address, 100);          
+        });
+
+        it("syntropicProducer must be false", async () => {
+          const producer = await instance.getProducer(prod1Address);
+
+          assert.equal(producer.syntropicProducer, true);
+        });
+
+        it("producer currentEra must be 2", async () => {
+          const producer = await instance.getProducer(prod1Address);
+
+          assert.equal(producer.pool.currentEra, 2);
         });
       });
     });

--- a/test/ProducerContract.test.js
+++ b/test/ProducerContract.test.js
@@ -543,7 +543,7 @@ contract("ProducerContract", (accounts) => {
           beforeEach(async () => {
             await instance.incrementInspections(prod1Address);
             await instance.incrementInspections(prod1Address);
-            await instance.incrementInspections(prod1Address);            
+            await instance.incrementInspections(prod1Address);
             await instance.setIsaScore(prod1Address, 1000);
 
             await addProducer("Producer B", prod2Address);
@@ -749,7 +749,7 @@ contract("ProducerContract", (accounts) => {
       context("when received 1 inspection", () => {
         it("syntropicProducer must be false", async () => {
           const producer = await instance.getProducer(prod1Address);
-    
+
           assert.equal(producer.syntropicProducer, false);
         });
 
@@ -785,7 +785,7 @@ contract("ProducerContract", (accounts) => {
           await instance.incrementInspections(prod1Address);
           await instance.setIsaScore(prod1Address, 100);
           await instance.incrementInspections(prod1Address);
-          await instance.setIsaScore(prod1Address, 100);          
+          await instance.setIsaScore(prod1Address, 100);
         });
 
         it("syntropicProducer must be false", async () => {

--- a/test/ProducerContract.test.js
+++ b/test/ProducerContract.test.js
@@ -94,7 +94,7 @@ contract("ProducerContract", (accounts) => {
       assert.equal(producer.isa.isaAverage, "0");
       assert.equal(producer.isa.isaScore, "0");
 
-      assert.equal(producer.pool.currentEra, 1);
+      assert.equal(producer.pool.currentEra, 0);
 
       assert.equal(producer.propertyAddress.country, "Brazil");
       assert.equal(producer.propertyAddress.state, "SP");
@@ -607,13 +607,13 @@ contract("ProducerContract", (accounts) => {
               it("producer A current era must be incremented", async () => {
                 const producer = await instance.getProducer(prod1Address);
 
-                assert.equal(producer.pool.currentEra, 2);
+                assert.equal(producer.pool.currentEra, 1);
               });
 
               it("producer B current era must be incremented", async () => {
                 const producer = await instance.getProducer(prod2Address);
 
-                assert.equal(producer.pool.currentEra, 2);
+                assert.equal(producer.pool.currentEra, 1);
               });
             });
 
@@ -632,7 +632,7 @@ contract("ProducerContract", (accounts) => {
               it("producer current era must be increment", async () => {
                 const producer = await instance.getProducer(prod1Address);
 
-                assert.equal(producer.pool.currentEra, 2);
+                assert.equal(producer.pool.currentEra, 1);
               });
             });
 

--- a/test/ProducerContract.test.js
+++ b/test/ProducerContract.test.js
@@ -161,6 +161,14 @@ contract("ProducerContract", (accounts) => {
 
       assert.equal(userType, PRODUCER);
     });
+
+    it("should create with certified equal false", async () => {
+      await addProducer("Producer A", prod1Address);
+
+      const producer = await instance.getProducer(prod1Address);
+
+      assert.equal(producer.certified, false);
+    });
   });
 
   context("when producer alredy exists", () => {


### PR DESCRIPTION
@everson-ever publiquei aqui a branch com o possível caminho pra resolver o problema da lógica de distribuição.

O problema é que, da forma que está, um produtor que conseguir "subornar" apenas 1 ativista na primeira inspeção, por mais que ele não vá conseguir sacar os tokens pq vai requerer 3 inspeções o resultado dessa inspeção entra no somatório da distribuição, pegando tokens que deveriam ser de outros usuários.

O que foi feito até aqui:

- Criação do bool 'certified', para verificar se um produtor foi certificado ou não.
- Produtor inicia com currentEra = 0
- Criação da função setCertificate que verifica se o produtor já recebeu 3 inspeções. Se sim, seta o bool certified como true e seta o producer.currentEra para a era atual da pool.
- Condicional na função setIsacore para verificar se o produtor for certificado, soma seu isaScore o producersTotalScore. 
- Alguns testes criados

Ainda não consegui validar se a lógica está funcionando. Falta criar diversos testes ainda.