### PR TITLE
add supporter burn tokens feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
+    branches: [ main, release ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/contracts/RcToken.sol
+++ b/contracts/RcToken.sol
@@ -57,7 +57,9 @@ contract RcToken is ERC20, Ownable {
     balances[receiver] = balances[receiver].add(numTokens);
     emit Transfer(tokenOwner, receiver, numTokens);
 
-    totalLocked_ -= numTokens;
+    unchecked {
+      if (contractsPools[tokenOwner]) totalLocked_ -= numTokens;
+    }
 
     return true;
   }
@@ -110,6 +112,12 @@ contract RcToken is ERC20, Ownable {
   function burnTokens(uint256 amount) public {
     _burn(_msgSender(), amount);
     certificate[msg.sender] += amount;
+    totalCertified_ += amount;
+  }
+
+  function burnTokensWith(address tokenOwner, uint256 amount) public mustBeContractPool {
+    _burn(tokenOwner, amount);
+    certificate[tokenOwner] += amount;
     totalCertified_ += amount;
   }
 

--- a/contracts/RcToken.sol
+++ b/contracts/RcToken.sol
@@ -110,12 +110,14 @@ contract RcToken is ERC20, Ownable {
   }
 
   function burnTokens(uint256 amount) public {
-    _burn(_msgSender(), amount);
-    certificate[msg.sender] += amount;
-    totalCertified_ += amount;
+    burnTokensInternal(msg.sender, amount);
   }
 
   function burnTokensWith(address tokenOwner, uint256 amount) public mustBeContractPool {
+    burnTokensInternal(tokenOwner, amount);
+  }
+
+  function burnTokensInternal(address tokenOwner, uint256 amount) internal {
     _burn(tokenOwner, amount);
     certificate[tokenOwner] += amount;
     totalCertified_ += amount;

--- a/contracts/SupporterContract.sol
+++ b/contracts/SupporterContract.sol
@@ -3,17 +3,20 @@ pragma solidity >=0.7.0 <=0.9.0;
 
 import { UserContract } from "./UserContract.sol";
 import { Supporter } from "./types/SupporterTypes.sol";
-import { UserType } from "./types/UserTypes.sol";
+import { UserType, Invitation } from "./types/UserTypes.sol";
+import { SupporterPool } from "./SupporterPool.sol";
 
 contract SupporterContract {
   mapping(address => Supporter) internal supporters;
 
   UserContract internal userContract;
+  SupporterPool internal supporterPool;
   address[] internal supportersAddress;
   uint256 public supportersCount;
 
-  constructor(address userContractAddress) {
+  constructor(address userContractAddress, address supporterPoolAddress) {
     userContract = UserContract(userContractAddress);
+    supporterPool = SupporterPool(supporterPoolAddress);
   }
 
   /**
@@ -33,6 +36,16 @@ contract SupporterContract {
     userContract.addUser(msg.sender, userType);
 
     return supporter;
+  }
+
+  function burnTokens(uint256 amount) public {
+    require(userContract.userTypeIs(UserType.SUPPORTER, msg.sender), "Only supporters");
+    require(amount > 0, "Amount invalid");
+
+    Invitation memory invitation = userContract.getInvitation(msg.sender);
+    bool isInvited = invitation.createdAtBlock != 0;
+
+    supporterPool.burnTokens(msg.sender, invitation.inviter, amount, isInvited);
   }
 
   /**

--- a/contracts/SupporterPool.sol
+++ b/contracts/SupporterPool.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0 <=0.9.0;
+
+import { Callable } from "./Callable.sol";
+import { RcToken } from "./RcToken.sol";
+import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+contract SupporterPool is Callable {
+  RcToken internal rcToken;
+
+  uint256 public constant INVITER_PERCENTAGE = 1;
+
+  using SafeMath for uint256;
+
+  constructor(address rcTokenAddress) {
+    rcToken = RcToken(rcTokenAddress);
+  }
+
+  event BurnTokens(address indexed _tokenOwner, uint256 _amount);
+  event InviterTokens(address indexed _tokenOwner, address indexed _inviter, uint256 _inviterTotalTokens);
+
+  function balance() public view returns (uint256) {
+    return balanceOf(address(this));
+  }
+
+  function balanceOf(address addr) public view returns (uint256) {
+    return rcToken.balanceOf(addr);
+  }
+
+  function burnTokens(address tokenOwner, address inviter, uint256 amount, bool isInvited) public mustBeAllowedCaller {
+    uint256 inviterTotalTokens = isInvited ? amount.mul(INVITER_PERCENTAGE).div(100) : 0;
+    amount = amount.sub(inviterTotalTokens);
+
+    rcToken.burnTokensWith(tokenOwner, amount);
+    emit BurnTokens(tokenOwner, amount);
+
+    if (!isInvited || inviterTotalTokens == 0) return;
+
+    rcToken.transferWith(tokenOwner, inviter, inviterTotalTokens);
+    emit InviterTokens(tokenOwner, inviter, inviterTotalTokens);
+  }
+}

--- a/contracts/SupporterPool.sol
+++ b/contracts/SupporterPool.sol
@@ -16,12 +16,13 @@ contract SupporterPool is Callable {
     rcToken = RcToken(rcTokenAddress);
   }
 
-  event BurnTokens(address indexed _tokenOwner, uint256 _amount);
-  event InviterTokens(address indexed _tokenOwner, address indexed _inviter, uint256 _inviterTotalTokens);
-
-  function balance() public view returns (uint256) {
-    return balanceOf(address(this));
-  }
+  event PoolBurnTokensEvent(
+    address indexed _tokenOwner,
+    uint256 _amountSend,
+    uint256 _amountBurned,
+    address indexed _inviter,
+    uint256 _inviterTotalTokens
+  );
 
   function balanceOf(address addr) public view returns (uint256) {
     return rcToken.balanceOf(addr);
@@ -29,14 +30,14 @@ contract SupporterPool is Callable {
 
   function burnTokens(address tokenOwner, address inviter, uint256 amount, bool isInvited) public mustBeAllowedCaller {
     uint256 inviterTotalTokens = isInvited ? amount.mul(INVITER_PERCENTAGE).div(100) : 0;
-    amount = amount.sub(inviterTotalTokens);
+    uint256 amountBurn = amount.sub(inviterTotalTokens);
 
-    rcToken.burnTokensWith(tokenOwner, amount);
-    emit BurnTokens(tokenOwner, amount);
+    rcToken.burnTokensWith(tokenOwner, amountBurn);
+
+    emit PoolBurnTokensEvent(tokenOwner, amount, amountBurn, inviter, inviterTotalTokens);
 
     if (!isInvited || inviterTotalTokens == 0) return;
 
     rcToken.transferWith(tokenOwner, inviter, inviterTotalTokens);
-    emit InviterTokens(tokenOwner, inviter, inviterTotalTokens);
   }
 }

--- a/contracts/UserContract.sol
+++ b/contracts/UserContract.sol
@@ -149,6 +149,10 @@ contract UserContract is Ownable, Callable {
     return delations[addr];
   }
 
+  function getInvitation(address addr) public view returns (Invitation memory) {
+    return invitations[addr];
+  }
+
   function exists(address addr) public view returns (bool) {
     return users[addr] != UserType.UNDEFINED;
   }

--- a/migrations/11_1_deploy_supporter_pool.js
+++ b/migrations/11_1_deploy_supporter_pool.js
@@ -1,0 +1,13 @@
+const RcToken = artifacts.require("RcToken");
+const SupporterPool = artifacts.require("SupporterPool");
+
+module.exports = function (deployer) {
+  deployer.then(async () => {
+    const rcToken = await RcToken.deployed();
+
+    const supporterPoolFunds = 0;
+
+    const supporterPool = await deployer.deploy(SupporterPool, rcToken.address);
+    await rcToken.addContractPool(supporterPool.address, supporterPoolFunds);
+  });
+};

--- a/migrations/11_deploy_supporter_contract.js
+++ b/migrations/11_deploy_supporter_contract.js
@@ -1,10 +1,14 @@
 const UserContract = artifacts.require("UserContract");
 const SupporterContract = artifacts.require("SupporterContract");
+const SupporterPool = artifacts.require("SupporterPool");
 
 module.exports = function (deployer) {
   deployer.then(async () => {
     const userContract = await UserContract.deployed();
+    const supporterPool = await SupporterPool.deployed();
 
-    await deployer.deploy(SupporterContract, userContract.address);
+    const supporterContract = await deployer.deploy(SupporterContract, userContract.address, supporterPool.address);
+
+    await supporterPool.newAllowedCaller(supporterContract.address);
   });
 };

--- a/migrations/7_1_deploy_researcher_contract.js
+++ b/migrations/7_1_deploy_researcher_contract.js
@@ -8,7 +8,12 @@ module.exports = function (deployer) {
     const researcherPool = await ResearcherPool.deployed();
     const timeBetweenWorks = process.env["RESEARCHER_TIME_BETWEEN_WORKS"];
 
-    const researcherContract = await deployer.deploy(ResearcherContract, userContract.address, researcherPool.address, timeBetweenWorks);
+    const researcherContract = await deployer.deploy(
+      ResearcherContract,
+      userContract.address,
+      researcherPool.address,
+      timeBetweenWorks
+    );
 
     await researcherPool.newAllowedCaller(researcherContract.address);
   });

--- a/test/RcToken.test.js
+++ b/test/RcToken.test.js
@@ -150,6 +150,28 @@ contract("RcToken", (accounts) => {
     });
   });
 
+  describe("#burnTokensWith", () => {
+    context("when msg.sender is a contractPool", () => {
+      beforeEach(async () => {
+        await instance.addContractPool(ownerAddress, 0);
+        await instance.transfer(user1Address, "200000000000000000000");
+        await instance.burnTokensWith(user1Address, "100000000000000000000", { from: ownerAddress });
+      });
+
+      it("should burn when has tokens", async () => {
+        const burnedTokens = await instance.balanceOf(user1Address);
+
+        assert.equal(burnedTokens, "100000000000000000000");
+      });
+    });
+
+    context("when msg.sender is not a contractPool", () => {
+      it("should return error", async () => {
+        await expectRevert(instance.burnTokensWith(user1Address, 100, { from: ownerAddress }), "Not a contract pool");
+      });
+    });
+  });
+
   describe("#totalLocked", () => {
     context("when add contract pool", () => {
       beforeEach(async () => {

--- a/test/SupporterContract.test.js
+++ b/test/SupporterContract.test.js
@@ -1,89 +1,106 @@
 const SupporterContract = artifacts.require("SupporterContract");
+const SupporterPool = artifacts.require("SupporterPool");
 const { userContractDeployed } = require("./shared/user_contract_deployed");
+const { userTypes } = require("./shared/user_types");
+const { rcTokenDeployed } = require("./shared/rc_token_deployed");
 
 const expectRevert = require("@openzeppelin/test-helpers").expectRevert;
 
 contract("SupporterContract", (accounts) => {
-  let instance;
-  let userContract;
-  let [ownerAddress, inv1Address, inv2Address] = accounts;
+  let instance, userContract, rcToken, supporterPool;
+  const [ownerAddress, inv1Address, inv2Address] = accounts;
 
   const addSupporter = async (name, address) => {
     await instance.addSupporter(name, { from: address });
   };
 
+  const transferTokensTo = async (userAddress, tokens) => {
+    await rcToken.transfer(userAddress, tokens);
+  };
+
   beforeEach(async () => {
     userContract = await userContractDeployed();
 
-    instance = await SupporterContract.new(userContract.address);
+    rcToken = await rcTokenDeployed();
+    supporterPool = await SupporterPool.new(rcToken.address);
+    instance = await SupporterContract.new(userContract.address, supporterPool.address);
 
     await userContract.newAllowedCaller(instance.address);
+    await userContract.newAllowedCaller(ownerAddress);
+    await supporterPool.newAllowedCaller(instance.address);
+    await rcToken.addContractPool(supporterPool.address, 0);
   });
 
-  context("when will create new supporter (.addSupporter)", () => {
+  describe("#addSupporter", () => {
     context("when supporter exists", () => {
       it("should return error", async () => {
         await addSupporter("Supporter A", inv1Address);
         await expectRevert(addSupporter("Supporter A", inv1Address), "This supporter already exist");
       });
+    });
 
-      context("when supporter don't exist", () => {
-        it("should create supporter", async () => {
-          await addSupporter("Supporter A", inv1Address);
-          await addSupporter("Supporter B", inv2Address);
-          const supporter = await instance.getSupporter(inv1Address);
+    context("when supporter don't exist", () => {
+      it("create supporter", async () => {
+        await addSupporter("Supporter A", inv1Address);
+        await addSupporter("Supporter B", inv2Address);
+        const supporter = await instance.getSupporter(inv1Address);
 
-          assert.equal(supporter.supporterWallet, inv1Address);
-        });
+        assert.equal(supporter.supporterWallet, inv1Address);
+      });
 
-        it("should increment supporterCount after create supporter", async () => {
-          await addSupporter("Supporter A", inv1Address);
-          await addSupporter("Supporter B", inv2Address);
-          const supportersCount = await instance.supportersCount();
+      it("increment supporterCount", async () => {
+        await addSupporter("Supporter A", inv1Address);
+        await addSupporter("Supporter B", inv2Address);
+        const supportersCount = await instance.supportersCount();
 
-          assert.equal(supportersCount, 2);
-        });
+        assert.equal(supportersCount, 2);
+      });
 
-        it("should add create supporter in supporterList (array)", async () => {
-          await addSupporter("Supporter A", inv1Address);
-          await addSupporter("Supporter B", inv2Address);
+      it("add created supporter in supporterList", async () => {
+        await addSupporter("Supporter A", inv1Address);
+        await addSupporter("Supporter B", inv2Address);
 
-          const supporters = await instance.getSupporters();
+        const supporters = await instance.getSupporters();
 
-          assert.equal(supporters[0].supporterWallet, inv1Address);
-        });
+        assert.equal(supporters[0].supporterWallet, inv1Address);
+      });
 
-        it("should add created supporter in userType contract as a SUPPORTER", async () => {
-          await addSupporter("Supporter A", inv1Address);
+      it("add created supporter in userType contract as a SUPPORTER", async () => {
+        await addSupporter("Supporter A", inv1Address);
 
-          const userType = await userContract.getUser(inv1Address);
-          const SUPPORTER = 7;
+        const userType = await userContract.getUser(inv1Address);
+        const SUPPORTER = 7;
 
-          assert.equal(userType, SUPPORTER);
-        });
+        assert.equal(userType, SUPPORTER);
       });
     });
   });
 
-  context("when will get supporters (.getSupporters)", () => {
-    it("should return supporters when has supporters", async () => {
-      await addSupporter("Supporter A", inv1Address);
-      await addSupporter("Supporter B", inv2Address);
+  describe("#getSupporters", () => {
+    context("when have supporters", () => {
+      beforeEach(async () => {
+        await addSupporter("Supporter A", inv1Address);
+        await addSupporter("Supporter B", inv2Address);
+      });
 
-      const supporters = await instance.getSupporters();
+      it("return supporters when has supporters", async () => {
+        const supporters = await instance.getSupporters();
 
-      assert.equal(supporters.length, 2);
+        assert.equal(supporters.length, 2);
+      });
     });
 
-    it("should return supporters equal zero when don't have it", async () => {
-      const supporters = await instance.getSupporters();
+    context("when dont have supporters", () => {
+      it("return empty supporters array", async () => {
+        const supporters = await instance.getSupporters();
 
-      assert.equal(supporters.length, 0);
+        assert.equal(supporters.length, 0);
+      });
     });
   });
 
-  context("when will get supporter (.getSupporter)", () => {
-    it("should return a supporter", async () => {
+  describe("#getSupporter", () => {
+    it("return a supporter", async () => {
       await addSupporter("Supporter A", inv1Address);
 
       const supporter = await instance.getSupporter(inv1Address);
@@ -92,18 +109,139 @@ contract("SupporterContract", (accounts) => {
     });
   });
 
-  context("when will check if supporter exists", () => {
-    it("should return true when exists", async () => {
-      await addSupporter("Supporter A", inv1Address);
-      const supporterExists = await instance.supporterExists(inv1Address);
+  context("#supporterExists", () => {
+    context("when supporter exists", () => {
+      beforeEach(async () => {
+        await addSupporter("Supporter A", inv1Address);
+      });
 
-      assert.equal(supporterExists, true);
+      it("return true", async () => {
+        const supporterExists = await instance.supporterExists(inv1Address);
+
+        assert.equal(supporterExists, true);
+      });
     });
 
-    it("it should return false when don't exist", async () => {
-      const supporterExists = await instance.supporterExists(inv1Address);
+    context("when supporter dont exists", () => {
+      it("return false", async () => {
+        const supporterExists = await instance.supporterExists(inv1Address);
 
-      assert.equal(supporterExists, false);
+        assert.equal(supporterExists, false);
+      });
+    });
+  });
+
+  describe("#burnTokens", () => {
+    context("when msg.sender is SUPPORTER", () => {
+      beforeEach(async () => {
+        await addSupporter("Supporter A", inv1Address);
+      });
+
+      context("when amount is greater than zero", () => {
+        context("when SUPPORTER was invited", () => {
+          beforeEach(async () => {
+            await userContract.addInvitation(inv1Address, inv2Address, userTypes.Supporter);
+            await addSupporter("Supporter B", inv2Address);
+            await transferTokensTo(inv2Address, 100000000000000000000n);
+          });
+
+          context("when burn 1000000000000000000 tokens", () => {
+            beforeEach(async () => {
+              await instance.burnTokens(1000000000000000000n, { from: inv2Address });
+            });
+
+            it("Supporter balance must be 99000000000000000000", async () => {
+              const balance = await supporterPool.balanceOf(inv2Address);
+              assert.equal(balance, 99000000000000000000n);
+            });
+
+            it("Supporter inviter balance must be 10000000000000000", async () => {
+              const balance = await supporterPool.balanceOf(inv1Address);
+              assert.equal(balance, 10000000000000000n);
+            });
+
+            it("totalCertified must be 990000000000000000", async () => {
+              const totalCertified = await rcToken.totalCertified();
+              assert.equal(totalCertified, 990000000000000000n);
+            });
+          });
+
+          context("when burn 500000000000000000 tokens", () => {
+            beforeEach(async () => {
+              await instance.burnTokens(500000000000000000n, { from: inv2Address });
+            });
+
+            it("Supporter balance must be 99500000000000000000", async () => {
+              const balance = await supporterPool.balanceOf(inv2Address);
+              assert.equal(balance, 99500000000000000000n);
+            });
+
+            it("Supporter inviter balance must be 5000000000000000", async () => {
+              const balance = await supporterPool.balanceOf(inv1Address);
+              assert.equal(balance, 5000000000000000n);
+            });
+
+            it("totalCertified must be 495000000000000000", async () => {
+              const totalCertified = await rcToken.totalCertified();
+              assert.equal(totalCertified, 495000000000000000n);
+            });
+          });
+        });
+
+        context("when SUPPORTER wasn't invited", () => {
+          beforeEach(async () => {
+            await transferTokensTo(inv1Address, "100000000000000000000");
+          });
+
+          context("when burn 1000000000000000000 tokens", () => {
+            beforeEach(async () => {
+              await instance.burnTokens(1000000000000000000n, { from: inv1Address });
+            });
+
+            it("Supporter balance must be 99000000000000000000", async () => {
+              const supporterBalance = await supporterPool.balanceOf(inv1Address);
+
+              assert.equal(supporterBalance, 99000000000000000000n);
+            });
+
+            it("totalCertified must be 1000000000000000000", async () => {
+              const totalCertified = await rcToken.totalCertified();
+
+              assert.equal(totalCertified, 1000000000000000000n);
+            });
+          });
+
+          context("when burn 500000000000000000 tokens", () => {
+            beforeEach(async () => {
+              await instance.burnTokens(500000000000000000n, { from: inv1Address });
+            });
+
+            it("Supporter balance must be 99500000000000000000", async () => {
+              const supporterBalance = await supporterPool.balanceOf(inv1Address);
+
+              assert.equal(supporterBalance, 99500000000000000000n);
+            });
+
+            it("totalCertified must be 500000000000000000", async () => {
+              const totalCertified = await rcToken.totalCertified();
+
+              assert.equal(totalCertified, 500000000000000000n);
+            });
+          });
+        });
+      });
+
+      context("when amount is equal zero", () => {
+        it("should return error", async () => {
+          await expectRevert(instance.burnTokens(0, { from: inv1Address }), "Amount invalid");
+        });
+      });
+    });
+
+    context("when msg.sender is not SUPPORTER", () => {
+      it("should return error", async () => {
+        await expectRevert(instance.burnTokens(1, { from: inv1Address }), "Only supporters");
+      });
     });
   });
 });

--- a/test/SupporterPool.test.js
+++ b/test/SupporterPool.test.js
@@ -1,0 +1,90 @@
+const SupporterPool = artifacts.require("SupporterPool");
+
+const expectEvent = require("@openzeppelin/test-helpers").expectEvent;
+const { rcTokenDeployed } = require("./shared/rc_token_deployed");
+
+contract("SupporterPool", (accounts) => {
+  let instance, rcToken;
+  let [owner, user1Address, user2Address] = accounts;
+
+  const transferTokensTo = async (userAddress, tokens) => {
+    await rcToken.transfer(userAddress, tokens);
+  };
+
+  beforeEach(async () => {
+    rcToken = await rcTokenDeployed();
+    instance = await SupporterPool.new(rcToken.address);
+
+    await instance.newAllowedCaller(owner);
+
+    await rcToken.addContractPool(instance.address, 0);
+  });
+
+  describe("#burnTokens", () => {
+    beforeEach(async () => {
+      await transferTokensTo(user1Address, "100000000000000000000");
+    });
+
+    context("when user was invited", () => {
+      beforeEach(async () => {
+        receipt = await instance.burnTokens(user1Address, user2Address, "1000000000000000000", true);
+      });
+
+      it("user1Address balance must be 99000000000000000000", async () => {
+        const balance = await instance.balanceOf(user1Address);
+        assert.equal(balance, 99000000000000000000n);
+      });
+
+      it("user2Address balance must be 10000000000000000", async () => {
+        const balance = await instance.balanceOf(user2Address);
+        assert.equal(balance, 10000000000000000n);
+      });
+
+      it("totalCertified must be 990000000000000000", async () => {
+        const totalCertified = await rcToken.totalCertified();
+        assert.equal(totalCertified, 990000000000000000n);
+      });
+
+      it("send PoolBurnTokensEvent", async () => {
+        expectEvent(receipt, "PoolBurnTokensEvent", {
+          _tokenOwner: user1Address,
+          _amountSend: web3.utils.toBN("1000000000000000000"),
+          _amountBurned: web3.utils.toBN("990000000000000000"),
+          _inviter: user2Address,
+          _inviterTotalTokens: web3.utils.toBN("10000000000000000"),
+        });
+      });
+    });
+
+    context("when user was not invited", () => {
+      beforeEach(async () => {
+        receipt = await instance.burnTokens(user1Address, user2Address, "1000000000000000000", false);
+      });
+
+      it("user1Address balance must be 99000000000000000000", async () => {
+        const balance = await instance.balanceOf(user1Address);
+        assert.equal(balance, 99000000000000000000n);
+      });
+
+      it("user2Address balance must be 0", async () => {
+        const balance = await instance.balanceOf(user2Address);
+        assert.equal(balance, 0);
+      });
+
+      it("totalCertified must be 1000000000000000000", async () => {
+        const totalCertified = await rcToken.totalCertified();
+        assert.equal(totalCertified, 1000000000000000000n);
+      });
+
+      it("send PoolBurnTokensEvent", async () => {
+        expectEvent(receipt, "PoolBurnTokensEvent", {
+          _tokenOwner: user1Address,
+          _amountSend: web3.utils.toBN("1000000000000000000"),
+          _amountBurned: web3.utils.toBN("1000000000000000000"),
+          _inviter: user2Address,
+          _inviterTotalTokens: web3.utils.toBN(0),
+        });
+      });
+    });
+  });
+});

--- a/test/UserContract.test.js
+++ b/test/UserContract.test.js
@@ -336,6 +336,20 @@ contract("UserContract", (accounts) => {
     context("without allowed caller", () => {});
   });
 
+  describe("#getInvitation", () => {
+    beforeEach(async () => {
+      await addInvitation(owner, user1Address, userTypes.Producer, owner);
+    });
+
+    it("returns invitation", async () => {
+      const invitation = await instance.getInvitation(user1Address);
+
+      assert.equal(invitation.inviter, owner);
+      assert.equal(invitation.userType, userTypes.Producer);
+      assert.equal(invitation.invited, user1Address);
+    });
+  });
+
   describe("#usersCount", () => {
     context("without users", () => {
       it("should usersCount be zero", async () => {


### PR DESCRIPTION
# #263 




# Script para testes


### Carregar contratos
```js
var supporterContract = await SupporterContract.deployed()
var rcToken = await RcToken.deployed()
var invitationContract = await InvitationContract.deployed()
```



### Cadastrar supporter sem convite
```js
await supporterContract.addSupporter("Supporter A", { from: accounts[1] })
```


### Convidar supporter:
```js
await invitationContract.invite(accounts[2], 7, { from: accounts[1] })
```

### Cadastrar supporter convidado
```js
await supporterContract.addSupporter("Supporter B", { from: accounts[2] })
```

### Enviando tokens para os dois supporters
```js
await rcToken.transfer(accounts[1], "100000000000000000000")
await rcToken.transfer(accounts[2], "100000000000000000000")
```
	
### Checando balance
```js
var balanceOf = await rcToken.balanceOf(accounts[1])
balanceOf.toString()

var balanceOf = await rcToken.balanceOf(accounts[2])
balanceOf.toString()
```
	
	
### Supporter não convidado queimando tokens
```js
await supporterContract.burnTokens("1000000000000000000", { from: accounts[1] })
```



### Supporter convidado queimando tokens

```js
await supporterContract.burnTokens("1000000000000000000", { from: accounts[2] })
```


:heavy_check_mark: 
```txt
A execução desse script vai resultar em
- O Supporter A (que não foi convidado) vai queimar 1 RC Token e todos vão ser enviados para o endereço 00000...
- O Supporter B (Que foi convidado pelo Supporter A) vai queimar 1 RC Token e 1% vai ser enviado para o Supporter A e o restante será enviado para o endereço 00000...
```

![image](https://github.com/Sintrop/core-contracts/assets/38266228/ea520079-4071-4bb4-9e94-8772a1e19a7a)
![image](https://github.com/Sintrop/core-contracts/assets/38266228/87eec28f-c7c5-4b49-95f7-f881ee341534)

