### PR TITLE
Split validation struct

### DIFF
--- a/contracts/Sintrop.sol
+++ b/contracts/Sintrop.sol
@@ -10,7 +10,7 @@ import { Inspector } from "./types/InspectorTypes.sol";
 import { UserContract } from "./UserContract.sol";
 import { UserType, Invitation } from "./types/UserTypes.sol";
 import { ValidatorContract } from "./ValidatorContract.sol";
-import { Validation } from "./types/ValidatorTypes.sol";
+import { InspectionValidation } from "./types/ValidatorTypes.sol";
 import { ActivistContract } from "./ActivistContract.sol";
 import { CategoryContract } from "./CategoryContract.sol";
 

--- a/contracts/ValidatorContract.sol
+++ b/contracts/ValidatorContract.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.7.0 <=0.9.0;
 
 import { UserContract } from "./UserContract.sol";
 import { ProducerContract } from "./ProducerContract.sol";
-import { Validator, Validation, Pool } from "./types/ValidatorTypes.sol";
+import { Validator, UserValidation, InspectionValidation, Pool } from "./types/ValidatorTypes.sol";
 import { UserType } from "./types/UserTypes.sol";
 import { Callable } from "./Callable.sol";
 import { ValidatorPool } from "./ValidatorPool.sol";
@@ -12,8 +12,8 @@ import { Inspection } from "./types/InspectionTypes.sol";
 
 contract ValidatorContract is Callable {
   mapping(address => Validator) internal validators;
-  mapping(address => Validation[]) private userValidations;
-  mapping(uint256 => Validation[]) public inspectionValidations;
+  mapping(address => UserValidation[]) private userValidations;
+  mapping(uint256 => InspectionValidation[]) public inspectionValidations;
   mapping(address => mapping(uint256 => bool)) internal validatorValidations;
 
   UserContract internal userContract;
@@ -58,7 +58,7 @@ contract ValidatorContract is Callable {
     uint256 validationsCount = userValidations[userAddress].length + 1;
 
     userValidations[userAddress].push(
-      Validation(msg.sender, userAddress, 0, justification, majorityValidatorsCount_, block.number)
+      UserValidation(msg.sender, userAddress, 0, justification, majorityValidatorsCount_, block.number)
     );
 
     if (validationsCount >= majorityValidatorsCount_) denieUser(userAddress);
@@ -78,7 +78,7 @@ contract ValidatorContract is Callable {
     bool addPenalty = inspection.validationsCount >= majorityValidatorsCount_;
 
     inspectionValidations[inspection.id].push(
-      Validation(
+      InspectionValidation(
         validatorAddress,
         inspection.acceptedBy,
         inspection.id,
@@ -129,11 +129,11 @@ contract ValidatorContract is Callable {
     if (oldUserType == UserType.INSPECTOR) return inspectorContract.resetLevels(userAddress, levels);
   }
 
-  function getUserValidations(address userAddress) public view returns (Validation[] memory) {
+  function getUserValidations(address userAddress) public view returns (UserValidation[] memory) {
     return userValidations[userAddress];
   }
 
-  function getInspectionValidations(uint256 inspectionId) public view returns (Validation[] memory) {
+  function getInspectionValidations(uint256 inspectionId) public view returns (InspectionValidation[] memory) {
     return inspectionValidations[inspectionId];
   }
 

--- a/contracts/types/ValidatorTypes.sol
+++ b/contracts/types/ValidatorTypes.sol
@@ -15,7 +15,16 @@ struct Pool {
   uint256 currentEra;
 }
 
-struct Validation {
+struct UserValidation {
+  address validator;
+  address user;
+  uint256 resourceId;
+  string justification;
+  uint256 majorityValidatorsCount;
+  uint256 createdAtBlockNumber;
+}
+
+struct InspectionValidation {
   address validator;
   address user;
   uint256 resourceId;


### PR DESCRIPTION
The same struct was being used for UserValidatios and InspectionValidations. Perhaps this was the issue with the problem that validators are not able to invalidate producers at v6.

#319 #311 