### PR TITLE
change hectares to square meters + remove unused constant

### DIFF
--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -64,7 +64,7 @@ contract RegeneratorRules is Callable {
     Coordinates[] memory _coordinates
   ) public {
     require(_coordinates.length >= 3 && _coordinates.length <= 10, "Minimum 3 and maximum 10 coordinate points");
-    require(totalArea >= 1000, "Minimum 1000 square meters");
+    require(totalArea >= 500, "Minimum 500 square meters");
 
     Regenerator memory regenerator = regenerators[msg.sender];
     uint256 id = communityRules.userTypesTotalCount(USER_TYPE) + 1;

--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -11,12 +11,11 @@ import { UserType } from "./types/CommunityTypes.sol";
  * @author Sintrop
  * @title RegeneratorRules
  * @dev Manage regenerator user logic.
- * @notice Person, family or a group of peolpe that are restoring nature
+ * @notice Person, family or a group of people that that are providing ecosystem regeneration services
  */
 contract RegeneratorRules is Callable {
   /// @notice Minimum inspections to regenerator receive tokens
   uint256 internal constant MINIMUM_INSPECTION_TO_POOL = 3;
-  uint256 internal constant LIMIT_REGENERATION_SCORE_TO_POOL = 1000;
 
   /// @notice The relationship between address and regenerator data
   mapping(address => Regenerator) public regenerators;
@@ -39,9 +38,10 @@ contract RegeneratorRules is Callable {
   /// @notice Regenerator UserType
   UserType private constant USER_TYPE = UserType.REGENERATOR;
 
+  /// @notice Valid impact regenerators
   uint256 public totalImpactRegenerators;
 
-  /// @notice [ha] 1 ha = 10000m²
+  /// @notice [m²]
   uint256 public regenerationArea;
 
   constructor(address communityRulesAddress, address regeneratorPoolAddress) {
@@ -51,9 +51,10 @@ contract RegeneratorRules is Callable {
 
   /**
    * @dev Allows a user to attempt to register as a regenerator
+   * @notice Register as a regenerator to add to the system an area under your supervision that is in process of regeneration
    * @param name The name of the regenerator
    * @param proofPhoto Identity photo
-   * @param totalArea in hectares = 1 ha = 10.000 m2
+   * @param totalArea in square meters [m²]
    * @param _coordinates the coordinates of the regenerator area
    */
   function addRegenerator(
@@ -63,6 +64,7 @@ contract RegeneratorRules is Callable {
     Coordinates[] memory _coordinates
   ) public {
     require(_coordinates.length >= 3 && _coordinates.length <= 10, "Minimum 3 and maximum 10 coordinate points");
+    require(totalArea >= 1000, "Minimum 1000 square meters");
 
     Regenerator memory regenerator = regenerators[msg.sender];
     uint256 id = communityRules.userTypesTotalCount(USER_TYPE) + 1;
@@ -116,15 +118,6 @@ contract RegeneratorRules is Callable {
    */
   function minimumInspections(uint256 totalInspections) private pure returns (bool) {
     return totalInspections >= MINIMUM_INSPECTION_TO_POOL;
-  }
-
-  /**
-   * @dev Checks if regenerator reached maxiumum score
-   * @param regenerator The regenerator
-   * @return bool True if reached
-   */
-  function limitRegenerationScore(Regenerator memory regenerator) private pure returns (bool) {
-    return regenerator.regenerationScore.score >= LIMIT_REGENERATION_SCORE_TO_POOL;
   }
 
   /**
@@ -236,13 +229,17 @@ contract RegeneratorRules is Callable {
   }
 
   /**
-   * @dev Calculate blocks to next era
+   * @notice Calculate blocks to next era
    * @return uint256 Return the amount of blocks to next era
    */
   function nextEraIn() public view returns (uint256) {
     return uint256(regeneratorPool.nextEraIn(regeneratorPoolEra()));
   }
 
+  /**
+   * @notice Total regeneration area
+   * @return uint256 Return the regeneration area [m²]
+   */
   function regenerationTotalArea() public view returns (uint256) {
     return regenerationArea;
   }

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -68,7 +68,7 @@ describe("InspectionRules", () => {
   };
 
   const addRegenerator = async (name, from) => {
-    await regeneratorRules.connect(from).addRegenerator(10, name, "photoURL", coordinates());
+    await regeneratorRules.connect(from).addRegenerator(1000, name, "photoURL", coordinates());
   };
 
   const coordinates = () => {

--- a/test/RegenerationCreditImpact.test.js
+++ b/test/RegenerationCreditImpact.test.js
@@ -22,7 +22,7 @@ describe("RegenerationCreditImpact", () => {
 
   const addRegenerator = async (name, from, _coordinates = []) => {
     const coordinatesParams = _coordinates.length > 0 ? _coordinates : coordinates();
-    await regeneratorRules.connect(from).addRegenerator(10, name, "photoURL", coordinatesParams);
+    await regeneratorRules.connect(from).addRegenerator(1000, name, "photoURL", coordinatesParams);
   };
 
   const addInspector = async (name, from) => {
@@ -558,10 +558,10 @@ describe("RegenerationCreditImpact", () => {
 
     context("when have two regenerators", () => {
       context("when all regenerators are valids", async () => {
-        it("totalSoilImpact must be 20", async () => {
+        it("totalSoilImpact must be 2000", async () => {
           const totalSoilImpact = await instance.totalSoilImpact();
 
-          expect(totalSoilImpact).to.equal(20);
+          expect(totalSoilImpact).to.equal(2000);
         });
       });
 
@@ -570,10 +570,10 @@ describe("RegenerationCreditImpact", () => {
           await regeneratorRules.removePoolLevels(regenerator2Address, 0);
         });
 
-        it("totalSoilImpact must be 10", async () => {
+        it("totalSoilImpact must be 1000", async () => {
           const totalSoilImpact = await instance.totalSoilImpact();
 
-          expect(totalSoilImpact).to.equal(10);
+          expect(totalSoilImpact).to.equal(1000);
         });
       });
     });
@@ -1065,10 +1065,10 @@ describe("RegenerationCreditImpact", () => {
     context("when have two regenerators", () => {
       context("when all regenerators are valids", async () => {
         context("when do not have tokens totalLocked_", () => {
-          it("tokenSoilImpact must be 1333333", async () => {
+          it("tokenSoilImpact must be 133333333", async () => {
             const tokenSoilImpact = await instance.tokenSoilImpact();
 
-            expect(tokenSoilImpact).to.equal(1333333);
+            expect(tokenSoilImpact).to.equal(133333333);
           });
         });
 
@@ -1078,10 +1078,10 @@ describe("RegenerationCreditImpact", () => {
             await regenerationCredit.addContractPool(ZERO_ADDRESS, 300000000000000000000000000n);
           });
 
-          it("tokenSoilImpact must be 2222222", async () => {
+          it("tokenSoilImpact must be 222222222", async () => {
             const tokenSoilImpact = await instance.tokenSoilImpact();
 
-            expect(tokenSoilImpact).to.equal(2222222);
+            expect(tokenSoilImpact).to.equal(222222222);
           });
         });
       });
@@ -1091,10 +1091,10 @@ describe("RegenerationCreditImpact", () => {
           await regeneratorRules.removePoolLevels(regenerator2Address, 0);
         });
 
-        it("tokenSoilImpact must be 666666", async () => {
+        it("tokenSoilImpact must be 66666666", async () => {
           const tokenSoilImpact = await instance.tokenSoilImpact();
 
-          expect(tokenSoilImpact).to.equal(666666);
+          expect(tokenSoilImpact).to.equal(66666666);
         });
       });
     });

--- a/test/RegeneratorRules.test.js
+++ b/test/RegeneratorRules.test.js
@@ -13,6 +13,11 @@ describe("RegeneratorRules", () => {
 
   const addRegenerator = async (name, from, _coordinates = []) => {
     const test = _coordinates.length > 0 ? _coordinates : coordinates();
+    await instance.connect(from).addRegenerator(1000, name, "photoURL", test);
+  };
+
+  const addRegenerator2 = async (name, from, _coordinates = []) => {
+    const test = _coordinates.length > 0 ? _coordinates : coordinates();
     await instance.connect(from).addRegenerator(10, name, "photoURL", test);
   };
 
@@ -85,7 +90,7 @@ describe("RegeneratorRules", () => {
       expect(regenerator.regeneratorWallet).to.equal(prod1Address.address);
       expect(regenerator.name).to.equal("Regenerator A");
       expect(regenerator.proofPhoto).to.equal("photoURL");
-      expect(regenerator.totalArea).to.equal("10");
+      expect(regenerator.totalArea).to.equal("1000");
       expect(regenerator.totalInspections).to.equal(0);
       expect(regenerator.pendingInspection).to.equal(false);
       expect(regenerator.regenerationScore.average).to.equal("0");
@@ -164,7 +169,7 @@ describe("RegeneratorRules", () => {
       await addRegenerator("Regenerator B", prod2Address);
 
       const newRegenerationArea = await instance.regenerationArea();
-      expect(newRegenerationArea).to.equal(20);
+      expect(newRegenerationArea).to.equal(2000);
     });
   });
 
@@ -235,6 +240,12 @@ describe("RegeneratorRules", () => {
           "Minimum 3 and maximum 10 coordinate points"
         );
       });
+    });
+  });
+
+  context("when totalArea is below 1000", () => {
+    it("should return error", async () => {
+      await expect(addRegenerator2("Regenerator A", prod1Address)).to.be.revertedWith("Minimum 1000 square meters");
     });
   });
 
@@ -331,7 +342,7 @@ describe("RegeneratorRules", () => {
             });
           });
 
-          context("when have more tha one regenerator", () => {
+          context("when have more than one regenerator", () => {
             beforeEach(async () => {
               await instance.afterRealizeInspection(prod1Address, 600);
               await addRegenerator("Regenerator B", prod2Address);

--- a/test/RegeneratorRules.test.js
+++ b/test/RegeneratorRules.test.js
@@ -245,7 +245,7 @@ describe("RegeneratorRules", () => {
 
   context("when totalArea is below 1000", () => {
     it("should return error", async () => {
-      await expect(addRegenerator2("Regenerator A", prod1Address)).to.be.revertedWith("Minimum 1000 square meters");
+      await expect(addRegenerator2("Regenerator A", prod1Address)).to.be.revertedWith("Minimum 500 square meters");
     });
   });
 

--- a/test/ValidatorRules.test.js
+++ b/test/ValidatorRules.test.js
@@ -117,7 +117,7 @@ describe("ValidatorRules", () => {
   };
 
   const addRegenerator = async (name, from) => {
-    await regeneratorRules.connect(from).addRegenerator(10, name, "photoURL", coordinates());
+    await regeneratorRules.connect(from).addRegenerator(1000, name, "photoURL", coordinates());
   };
 
   const coordinates = () => {
@@ -521,7 +521,7 @@ describe("ValidatorRules", () => {
               it("regenerationArea should be decremented", async () => {
                 const decrementedArea = await regeneratorRules.regenerationArea();
 
-                expect(decrementedArea).to.equal(10);
+                expect(decrementedArea).to.equal(1000);
               });
 
               it("must emit DeniedUserEevent", async () => {


### PR DESCRIPTION
Variable totalArea from regenerators changed from hectares to square meters. Also removed an unused old constant from old sustainable logic. 

Now there is a minimum of 500 m² to register as a regenerator in the system. 