### PR TITLE
Trees refact

### DIFF
--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -52,7 +52,7 @@ contract InspectionRules is Callable {
 
   uint256 public inspectionsCount;
   uint256 public inspectionsTotalCount;
-  uint256 public inspectionsBiomassImpact;
+  uint256 public inspectionsTreesImpact;
   uint256 public inspectionsBiodiversityImpact;
   uint256 public immutable timeBetweenInspections;
   uint256 public immutable blocksToExpireAcceptedInspection;
@@ -91,7 +91,8 @@ contract InspectionRules is Callable {
   }
 
   /**
-   * @dev Allows the current user (regenerator) request a inspection.
+   * @dev Allows the current user (regenerator) request a inspection
+   * @notice When requesting an inspection, the regenerator agrees to receive an inspector to assess the area under regeneration
    */
   function requestInspection() public {
     Regenerator memory regenerator = regeneratorRules.getRegenerator(msg.sender);
@@ -125,6 +126,7 @@ contract InspectionRules is Callable {
 
   /**
    * @dev Allows the current user (inspector) accept a inspection.
+   * @notice Inspectors must only accept inspections that they can perform
    * @param inspectionId The id of the inspection that the inspector want accept.
    */
   function acceptInspection(uint256 inspectionId) public {
@@ -151,33 +153,36 @@ contract InspectionRules is Callable {
 
   /**
    * @dev Allow a inspector realize a inspection and mark as INSPECTED
+   * @notice Inspectors must evaluate the amount of trees and species of the regeneration area
    * @param inspectionId The id of the inspection to be realized
-   * @param biomassResult The RegenerationInspection[] of the inspection to be realized
-   * @param biodiversityResult The RegenerationInspection[] of the inspection to be realized
+   * @param proofPhoto The string of a photo with the regenerator or at the regeneration area
+   * @param treesResult The number of trees, palm trees and other plants larger than 5cm in diamater found in the regeneration area. Only plants managed or planted by the regenerator must be counted
+   * @param biodiversityResult The number of different species of trees, palm trees and other plants larger than 5 cm in diameter found in the regeneration area. Only plants managed or planted by the regenerator must be counted
+   * @param report The justification of the result found
    */
   function realizeInspection(
     uint256 inspectionId,
     string memory proofPhoto,
     string memory report,
-    RegenerationInspection memory biomassResult,
+    RegenerationInspection memory treesResult,
     RegenerationInspection memory biodiversityResult
   ) public {
     Inspection memory inspection = inspections[inspectionId];
 
     require(
-      biomassResult.categoryId == 1 && biodiversityResult.categoryId == 2,
-      "Invalid biomassResult or biodiversityResult"
+      treesResult.categoryId == 1 && biodiversityResult.categoryId == 2,
+      "Invalid treesResult or biodiversityResult"
     );
     require(communityRules.userTypeIs(UserType.INSPECTOR, msg.sender), "Please register as inspector");
     require(inspection.status == InspectionStatus.ACCEPTED, "Accept this inspection before");
     require(inspection.inspector == msg.sender, "You have not accepted this inspection");
     require(!(block.number > inspection.acceptedAt + blocksToExpireAcceptedInspection), "Inspection Expired");
 
-    markAsRealized(inspection, proofPhoto, report, biomassResult, biodiversityResult);
+    markAsRealized(inspection, proofPhoto, report, treesResult, biodiversityResult);
 
     afterRealizeInspection(inspection);
 
-    inspectionsBiomassImpact += biomassResult.indicator;
+    inspectionsTreesImpact += treesResult.indicator;
     inspectionsBiodiversityImpact += biodiversityResult.indicator;
     inspectorInspected[msg.sender][inspection.regenerator] = true;
   }
@@ -186,11 +191,11 @@ contract InspectionRules is Callable {
     Inspection memory inspection,
     string memory proofPhoto,
     string memory report,
-    RegenerationInspection memory biomassResult,
+    RegenerationInspection memory treesResult,
     RegenerationInspection memory biodiversityResult
   ) internal {
     inspection.status = InspectionStatus.INSPECTED;
-    inspection.regenerationScore = regenerationIndexRules.calculateScore(biomassResult, biodiversityResult);
+    inspection.regenerationScore = regenerationIndexRules.calculateScore(treesResult, biodiversityResult);
     inspection.proofPhoto = proofPhoto;
     inspection.report = report;
     inspection.inspectedAt = block.number;
@@ -198,7 +203,7 @@ contract InspectionRules is Callable {
 
     inspections[inspection.id] = inspection;
 
-    regenerationInspection[inspection.id][1] = biomassResult;
+    regenerationInspection[inspection.id][1] = treesResult;
     regenerationInspection[inspection.id][2] = biodiversityResult;
   }
 
@@ -239,7 +244,7 @@ contract InspectionRules is Callable {
   }
 
   function invalidateInspection(Inspection memory inspection) internal {
-    inspectionsBiomassImpact -= regenerationInspection[inspection.id][1].indicator;
+    inspectionsTreesImpact -= regenerationInspection[inspection.id][1].indicator;
     inspectionsBiodiversityImpact -= regenerationInspection[inspection.id][2].indicator;
     inspectionsCount--;
     inspection.status = InspectionStatus.INVALIDATED;

--- a/contracts/RegenerationCreditImpact.sol
+++ b/contracts/RegenerationCreditImpact.sol
@@ -20,7 +20,14 @@ contract RegenerationCreditImpact {
   /// @notice Constant of 32 decimals to calculate the impact. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
   uint256 public constant IMPACT_DECIMALS = 10 ** 32;
 
-  /// @notice [kg]
+  /**
+   * @notice [kg]
+   * This constant estimates an average carbon sequestration of 100 kg per tree, palm tree and other plants with more than 5cm in diameter recorded by inspectors. 
+   * In practice, it is not so simple to make this relationship, as the actual amount of carbon sequestered will vary from species to species,
+   * from biome to biome, from soil to soil, from management to management and from each geolocation.
+   * However, we need to standardize this value to simplify and allow the decentralized certification system to occur.
+   * This result was obtained by estimating that, on average, each tree/plant sequesters 10 kg of carbon per year, living an average of 10 years.
+   */  
   uint256 public constant CARBON_PER_TREE = 100;
 
   RegenerationCredit internal regenerationCredit;
@@ -41,7 +48,8 @@ contract RegenerationCreditImpact {
   }
 
   /**
-   * @dev Function to calculate the total trees impact of the system.
+   * @notice Function to calculate the total trees impact of the system.
+   * @return uint256 Amount of trees
    */
   function totalTreesImpact() public view returns (uint256) {
     if (inspectionRules.inspectionsCount() == 0) return 0;
@@ -52,6 +60,10 @@ contract RegenerationCreditImpact {
       );      
   }
 
+  /**
+   * @notice Function to calculate the total carbon impact of the system.
+   * @return uint256 Kg of carbon [kg]
+   */
   function totalCarbonImpact() public view returns (uint256) {
     if (inspectionRules.inspectionsCount() == 0) return 0;
 
@@ -60,7 +72,8 @@ contract RegenerationCreditImpact {
   }
 
   /**
-   * @dev Function to calculate the total biodiversity impact of the system.
+   * @notice Function to calculate the total biodiversity impact of the system.
+   * @return uint256 Amount of species 
    */
   function totalBiodiversityImpact() public view returns (uint256) {
     if (inspectionRules.inspectionsCount() == 0) return 0;
@@ -72,7 +85,8 @@ contract RegenerationCreditImpact {
   }
 
   /**
-   * @dev Function to calculate the total soil impact of the system.
+   * @notice Function to calculate the total soil impact of the system.
+   * @return uint256 Area under regeneration [m²]
    */
   function totalSoilImpact() public view returns (uint256) {
     return regeneratorRules.regenerationArea();
@@ -82,14 +96,19 @@ contract RegenerationCreditImpact {
    * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
    * @notice Function that calculates the trees impact per regeneration credit.
    */
-  function tokenTreesImpact() public view returns (uint256) {
+  function treesPerToken() public view returns (uint256) {
     return
       totalTreesImpact().mul(IMPACT_DECIMALS).div(
         regenerationCredit.totalSupply_() + regenerationCredit.totalCertified_() - regenerationCredit.totalLocked_()
       );
   }
 
-  function tokenCarbonImpact() public view returns (uint256) {
+  /**
+   * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
+   * @notice Function that calculates the carbon impact per regeneration credit.
+   * @return uint256 Kg of carbon [kg]
+   */
+  function carbonPerToken() public view returns (uint256) {
     return
       totalCarbonImpact().mul(IMPACT_DECIMALS).div(
         regenerationCredit.totalSupply_() + regenerationCredit.totalCertified_() - regenerationCredit.totalLocked_()
@@ -100,7 +119,7 @@ contract RegenerationCreditImpact {
    * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
    * @notice Function that calculates the biodiversity impact per regeneration credit.
    */
-  function tokenBiodiversityImpact() public view returns (uint256) {
+  function biodiversityPerToken() public view returns (uint256) {
     return
       totalBiodiversityImpact().mul(IMPACT_DECIMALS).div(
         regenerationCredit.totalSupply_() + regenerationCredit.totalCertified_() - regenerationCredit.totalLocked_()
@@ -110,9 +129,9 @@ contract RegenerationCreditImpact {
   /**
    * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
    * @notice Function that calculates the soil impact per regeneration credit
-   * @return uint256 [m²]
+   * @return uint256 Area [m²]
    */
-  function tokenSoilImpact() public view returns (uint256) {
+  function soilPerToken() public view returns (uint256) {
     return
       totalSoilImpact().mul(IMPACT_DECIMALS).div(
         regenerationCredit.totalSupply_() + regenerationCredit.totalCertified_() - regenerationCredit.totalLocked_()

--- a/contracts/RegenerationCreditImpact.sol
+++ b/contracts/RegenerationCreditImpact.sol
@@ -22,12 +22,12 @@ contract RegenerationCreditImpact {
 
   /**
    * @notice [kg]
-   * This constant estimates an average carbon sequestration of 100 kg per tree, palm tree and other plants with more than 5cm in diameter recorded by inspectors. 
+   * This constant estimates an average carbon sequestration of 100 kg per tree, palm tree and other plants with more than 5cm in diameter recorded by inspectors.
    * In practice, it is not so simple to make this relationship, as the actual amount of carbon sequestered will vary from species to species,
    * from biome to biome, from soil to soil, from management to management and from each geolocation.
    * However, we need to standardize this value to simplify and allow the decentralized certification system to occur.
    * This result was obtained by estimating that, on average, each tree/plant sequesters 10 kg of carbon per year, living an average of 10 years.
-   */  
+   */
   uint256 public constant CARBON_PER_TREE = 100;
 
   RegenerationCredit internal regenerationCredit;
@@ -57,7 +57,7 @@ contract RegenerationCreditImpact {
     return
       inspectionRules.inspectionsTreesImpact().div(inspectionRules.inspectionsCount()).mul(
         regeneratorRules.totalImpactRegenerators()
-      );      
+      );
   }
 
   /**
@@ -67,13 +67,12 @@ contract RegenerationCreditImpact {
   function totalCarbonImpact() public view returns (uint256) {
     if (inspectionRules.inspectionsCount() == 0) return 0;
 
-    return
-      totalTreesImpact().mul(CARBON_PER_TREE);
+    return totalTreesImpact().mul(CARBON_PER_TREE);
   }
 
   /**
    * @notice Function to calculate the total biodiversity impact of the system.
-   * @return uint256 Amount of species 
+   * @return uint256 Amount of species
    */
   function totalBiodiversityImpact() public view returns (uint256) {
     if (inspectionRules.inspectionsCount() == 0) return 0;
@@ -113,7 +112,7 @@ contract RegenerationCreditImpact {
       totalCarbonImpact().mul(IMPACT_DECIMALS).div(
         regenerationCredit.totalSupply_() + regenerationCredit.totalCertified_() - regenerationCredit.totalLocked_()
       );
-  }  
+  }
 
   /**
    * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.

--- a/contracts/RegenerationCreditImpact.sol
+++ b/contracts/RegenerationCreditImpact.sol
@@ -20,6 +20,9 @@ contract RegenerationCreditImpact {
   /// @notice Constant of 32 decimals to calculate the impact. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
   uint256 public constant IMPACT_DECIMALS = 10 ** 32;
 
+  /// @notice [kg]
+  uint256 public constant CARBON_PER_TREE = 100;
+
   RegenerationCredit internal regenerationCredit;
   InspectionRules internal inspectionRules;
   CommunityRules internal communityRules;
@@ -40,12 +43,20 @@ contract RegenerationCreditImpact {
   /**
    * @dev Function to calculate the total carbon impact of the system. It is calculated by dividing the biomass impact by 2, which represents that half of the biomass weight is composed by carbon.
    */
+  function totalTreesImpact() public view returns (uint256) {
+    if (inspectionRules.inspectionsCount() == 0) return 0;
+
+    return
+      inspectionRules.inspectionsTreesImpact().div(inspectionRules.inspectionsCount()).mul(
+        regeneratorRules.totalImpactRegenerators()
+      );      
+  }
+
   function totalCarbonImpact() public view returns (uint256) {
     if (inspectionRules.inspectionsCount() == 0) return 0;
 
     return
-      ((inspectionRules.inspectionsBiomassImpact().div(2)) / inspectionRules.inspectionsCount()) *
-      regeneratorRules.totalImpactRegenerators();
+      totalTreesImpact().mul(CARBON_PER_TREE);
   }
 
   /**
@@ -71,12 +82,19 @@ contract RegenerationCreditImpact {
    * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
    * @notice Function that calculates the carbon impact per regeneration credit.
    */
+  function tokenTreesImpact() public view returns (uint256) {
+    return
+      totalTreesImpact().mul(IMPACT_DECIMALS).div(
+        regenerationCredit.totalSupply_() + regenerationCredit.totalCertified_() - regenerationCredit.totalLocked_()
+      );
+  }
+
   function tokenCarbonImpact() public view returns (uint256) {
     return
       totalCarbonImpact().mul(IMPACT_DECIMALS).div(
         regenerationCredit.totalSupply_() + regenerationCredit.totalCertified_() - regenerationCredit.totalLocked_()
       );
-  }
+  }  
 
   /**
    * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.

--- a/contracts/RegenerationCreditImpact.sol
+++ b/contracts/RegenerationCreditImpact.sol
@@ -41,7 +41,7 @@ contract RegenerationCreditImpact {
   }
 
   /**
-   * @dev Function to calculate the total carbon impact of the system. It is calculated by dividing the biomass impact by 2, which represents that half of the biomass weight is composed by carbon.
+   * @dev Function to calculate the total trees impact of the system.
    */
   function totalTreesImpact() public view returns (uint256) {
     if (inspectionRules.inspectionsCount() == 0) return 0;
@@ -80,7 +80,7 @@ contract RegenerationCreditImpact {
 
   /**
    * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
-   * @notice Function that calculates the carbon impact per regeneration credit.
+   * @notice Function that calculates the trees impact per regeneration credit.
    */
   function tokenTreesImpact() public view returns (uint256) {
     return
@@ -109,7 +109,8 @@ contract RegenerationCreditImpact {
 
   /**
    * @dev 32 decimal places are used for the calculation. To get the exact result, it is necessary to add 32 decimal places to the value returned by the function.
-   * @notice Function that calculates the soil impact per regeneration credit.
+   * @notice Function that calculates the soil impact per regeneration credit
+   * @return uint256 [m²]
    */
   function tokenSoilImpact() public view returns (uint256) {
     return

--- a/contracts/RegenerationIndexRules.sol
+++ b/contracts/RegenerationIndexRules.sol
@@ -91,20 +91,20 @@ contract RegenerationIndexRules is Ownable, Callable {
     RegenerationInspection memory treesResult,
     RegenerationInspection memory biodiversityResult
   ) public view returns (uint256) {
-    RegenerationIndex memory carbon = regenerationIndex[biomassRegenerationIndexId(treesResult.indicator)];
+    RegenerationIndex memory trees = regenerationIndex[treesRegenerationIndexId(treesResult.indicator)];
     RegenerationIndex memory biodiversity = regenerationIndex[
       biodiversityRegenerationIndexId(biodiversityResult.indicator)
     ];
 
-    return carbon.value + biodiversity.value;
+    return trees.value + biodiversity.value;
   }
 
   /**
-   * @dev Function to calculate the biomass inspection score
+   * @dev Function to calculate the trees inspection score
    * @param indicator The result provided by the inspector
    * @return The category regeneration score
    */
-  function biomassRegenerationIndexId(uint256 indicator) internal pure returns (uint256) {
+  function treesRegenerationIndexId(uint256 indicator) internal pure returns (uint256) {
     if (indicator > 100000) {
       return 1;
     } else if (indicator > 10000 && indicator < 100000) {

--- a/contracts/RegenerationIndexRules.sol
+++ b/contracts/RegenerationIndexRules.sol
@@ -39,35 +39,35 @@ contract RegenerationIndexRules is Ownable, Callable {
    * @dev create categories to the system
    */
   function addCategories() internal {
-    Category memory biomassCategory = Category(
+    Category memory treesCategory = Category(
       1,
-      "Biomass",
-      "Indicator to measure the total amount of biomass in the regenerating area. How much organic matter is there on the site? Estimate by including living biomass, such as trees, plants and roots, as well as dead biomass, which includes leaves, branches, wood and other types of organic matter covering the soil. The result should be expressed in tons [t]"
+      "Trees",
+      "Indicator to measure the total amount of trees, palm trees and other plants over 5cm in diameter in the regenerating area. How many trees, palm trees and other plants with more than 5cm of diameters there is in the regenerating area? Justify your answer in the report."
     );
 
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(1, "Balance > 100.000"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(2, "100.000 > Balance > 10.000"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(3, "10.000 > Balance > 1000"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(4, "1000 > Balance > 100"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(5, "100 > Balance > 10"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(6, "10 > Balance > 0"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(7, "Not applicable"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(1, "Trees > 10000"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(2, "10000 > Trees > 4000"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(3, "4000 > Trees > 2000"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(4, "2000 > Trees > 500"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(5, "500 > Trees > 100"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(6, "100 > Trees > 10"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(7, "Trees < 10"));
 
     Category memory biodiversityCategory = Category(
       2,
       "Biodiversity",
-      "Indicator to measure the level of plant biodiversity in the regenerating area. How many different species are there in the area? Each different species is equivalent to one point and only trees and plants managed or planted by the regenerator should be counted"
+      "Indicator to measure the level of biodiversity of trees, palm trees and other plants over 5cm of diamater in the regenerating area. How many different species are there in the area? Each different species is equivalent to one point and only trees and plants managed or planted by the regenerator should be counted."
     );
 
-    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(1, "Biodiversity > 1000"));
-    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(2, "1000 > Biodiversity > 500"));
-    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(3, "500 > Biodiversity > 200"));
-    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(4, "200 > Biodiversity > 100"));
-    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(5, "100 > Biodiversity > 50"));
-    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(6, "50 > Biodiversity > 25"));
-    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(7, "Biodiversity < 25"));
+    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(1, "Biodiversity > 240"));
+    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(2, "240 > Biodiversity > 120"));
+    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(3, "120 > Biodiversity > 60"));
+    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(4, "60 > Biodiversity > 30"));
+    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(5, "30 > Biodiversity > 15"));
+    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(6, "15 > Biodiversity > 5"));
+    categoryRegenerationIndexDescriptions[2].push(RegenerationIndexDescription(7, "Biodiversity < 5"));
 
-    categories[1] = biomassCategory;
+    categories[1] = treesCategory;
     categories[2] = biodiversityCategory;
   }
 
@@ -83,15 +83,15 @@ contract RegenerationIndexRules is Ownable, Callable {
 
   /**
    * @dev Function to calculate the inspection score
-   * @param biomassResult Inspection result provided by inspector
+   * @param treesResult Inspection result provided by inspector
    * @param biodiversityResult Inspection result provided by inspector
    * @return int256 Inspection score
    */
   function calculateScore(
-    RegenerationInspection memory biomassResult,
+    RegenerationInspection memory treesResult,
     RegenerationInspection memory biodiversityResult
   ) public view returns (uint256) {
-    RegenerationIndex memory carbon = regenerationIndex[biomassRegenerationIndexId(biomassResult.indicator)];
+    RegenerationIndex memory carbon = regenerationIndex[biomassRegenerationIndexId(treesResult.indicator)];
     RegenerationIndex memory biodiversity = regenerationIndex[
       biodiversityRegenerationIndexId(biodiversityResult.indicator)
     ];

--- a/contracts/RegenerationIndexRules.sol
+++ b/contracts/RegenerationIndexRules.sol
@@ -22,12 +22,12 @@ contract RegenerationIndexRules is Ownable, Callable {
   uint256 public categoryCounts;
 
   constructor() {
-    regenerationIndex[1] = RegenerationIndex("REGENERATIVO 6", 32);
-    regenerationIndex[2] = RegenerationIndex("REGENERATIVO 5", 16);
-    regenerationIndex[3] = RegenerationIndex("REGENERATIVO 4", 8);
-    regenerationIndex[4] = RegenerationIndex("REGENERATIVO 3", 4);
-    regenerationIndex[5] = RegenerationIndex("REGENERATIVO 2", 2);
-    regenerationIndex[6] = RegenerationIndex("REGENERATIVO 1", 1);
+    regenerationIndex[1] = RegenerationIndex("REGENERATIVE 6", 32);
+    regenerationIndex[2] = RegenerationIndex("REGENERATIVE 5", 16);
+    regenerationIndex[3] = RegenerationIndex("REGENERATIVE 4", 8);
+    regenerationIndex[4] = RegenerationIndex("REGENERATIVE 3", 4);
+    regenerationIndex[5] = RegenerationIndex("REGENERATIVE 2", 2);
+    regenerationIndex[6] = RegenerationIndex("REGENERATIVE 1", 1);
     regenerationIndex[7] = RegenerationIndex("NEUTRO", 0);
 
     addCategories();
@@ -45,11 +45,11 @@ contract RegenerationIndexRules is Ownable, Callable {
       "Indicator to measure the total amount of trees, palm trees and other plants over 5cm in diameter in the regenerating area. How many trees, palm trees and other plants with more than 5cm of diameters there is in the regenerating area? Justify your answer in the report."
     );
 
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(1, "Trees > 10000"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(2, "10000 > Trees > 4000"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(3, "4000 > Trees > 2000"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(4, "2000 > Trees > 500"));
-    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(5, "500 > Trees > 100"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(1, "Trees > 20000"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(2, "20000 > Trees > 10000"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(3, "10000 > Trees > 5000"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(4, "5000 > Trees > 1000"));
+    categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(5, "1000 > Trees > 100"));
     categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(6, "100 > Trees > 10"));
     categoryRegenerationIndexDescriptions[1].push(RegenerationIndexDescription(7, "Trees < 10"));
 
@@ -105,17 +105,17 @@ contract RegenerationIndexRules is Ownable, Callable {
    * @return The category regeneration score
    */
   function treesRegenerationIndexId(uint256 indicator) internal pure returns (uint256) {
-    if (indicator > 100000) {
+    if (indicator > 20000) {
       return 1;
-    } else if (indicator > 10000 && indicator < 100000) {
+    } else if (indicator > 10000 && indicator < 20000) {
       return 2;
-    } else if (indicator > 1000 && indicator < 10000) {
+    } else if (indicator > 5000 && indicator < 10000) {
       return 3;
-    } else if (indicator > 100 && indicator < 1000) {
+    } else if (indicator > 1000 && indicator < 5000) {
       return 4;
-    } else if (indicator > 10 && indicator < 100) {
+    } else if (indicator > 100 && indicator < 1000) {
       return 5;
-    } else if (indicator > 0 && indicator < 10) {
+    } else if (indicator > 10 && indicator < 100) {
       return 6;
     } else {
       return 7;
@@ -128,17 +128,17 @@ contract RegenerationIndexRules is Ownable, Callable {
    * @return The category regeneration score
    */
   function biodiversityRegenerationIndexId(uint256 indicator) internal pure returns (uint256) {
-    if (indicator > 1000) {
+    if (indicator > 240) {
       return 1;
-    } else if (indicator > 500 && indicator < 1000) {
+    } else if (indicator > 120 && indicator < 240) {
       return 2;
-    } else if (indicator > 200 && indicator < 500) {
+    } else if (indicator > 60 && indicator < 120) {
       return 3;
-    } else if (indicator > 100 && indicator < 200) {
+    } else if (indicator > 30 && indicator < 60) {
       return 4;
-    } else if (indicator > 50 && indicator < 100) {
+    } else if (indicator > 15 && indicator < 30) {
       return 5;
-    } else if (indicator > 25 && indicator < 50) {
+    } else if (indicator > 5 && indicator < 15) {
       return 6;
     } else {
       return 7;

--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -64,7 +64,7 @@ contract RegeneratorRules is Callable {
     Coordinates[] memory _coordinates
   ) public {
     require(_coordinates.length >= 3 && _coordinates.length <= 10, "Minimum 3 and maximum 10 coordinate points");
-    require(totalArea >= 1000, "Minimum 1000 square meters");
+    require(totalArea >= 500, "Minimum 500 square meters");
 
     Regenerator memory regenerator = regenerators[msg.sender];
     uint256 id = communityRules.userTypesTotalCount(USER_TYPE) + 1;

--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -11,12 +11,11 @@ import { UserType } from "./types/CommunityTypes.sol";
  * @author Sintrop
  * @title RegeneratorRules
  * @dev Manage regenerator user logic.
- * @notice Person, family or a group of peolpe that are restoring nature
+ * @notice Person, family or a group of people that that are providing ecosystem regeneration services
  */
 contract RegeneratorRules is Callable {
   /// @notice Minimum inspections to regenerator receive tokens
   uint256 internal constant MINIMUM_INSPECTION_TO_POOL = 3;
-  uint256 internal constant LIMIT_REGENERATION_SCORE_TO_POOL = 1000;
 
   /// @notice The relationship between address and regenerator data
   mapping(address => Regenerator) public regenerators;
@@ -39,9 +38,10 @@ contract RegeneratorRules is Callable {
   /// @notice Regenerator UserType
   UserType private constant USER_TYPE = UserType.REGENERATOR;
 
+  /// @notice Valid impact regenerators
   uint256 public totalImpactRegenerators;
 
-  /// @notice [ha] 1 ha = 10000m²
+  /// @notice [m²]
   uint256 public regenerationArea;
 
   constructor(address communityRulesAddress, address regeneratorPoolAddress) {
@@ -51,9 +51,10 @@ contract RegeneratorRules is Callable {
 
   /**
    * @dev Allows a user to attempt to register as a regenerator
+   * @notice Register as a regenerator to add to the system an area under your supervision that is in process of regeneration
    * @param name The name of the regenerator
    * @param proofPhoto Identity photo
-   * @param totalArea in hectares = 1 ha = 10.000 m2
+   * @param totalArea in square meters [m²]
    * @param _coordinates the coordinates of the regenerator area
    */
   function addRegenerator(
@@ -63,6 +64,7 @@ contract RegeneratorRules is Callable {
     Coordinates[] memory _coordinates
   ) public {
     require(_coordinates.length >= 3 && _coordinates.length <= 10, "Minimum 3 and maximum 10 coordinate points");
+    require(totalArea >= 1000, "Minimum 1000 square meters");
 
     Regenerator memory regenerator = regenerators[msg.sender];
     uint256 id = communityRules.userTypesTotalCount(USER_TYPE) + 1;
@@ -116,15 +118,6 @@ contract RegeneratorRules is Callable {
    */
   function minimumInspections(uint256 totalInspections) private pure returns (bool) {
     return totalInspections >= MINIMUM_INSPECTION_TO_POOL;
-  }
-
-  /**
-   * @dev Checks if regenerator reached maxiumum score
-   * @param regenerator The regenerator
-   * @return bool True if reached
-   */
-  function limitRegenerationScore(Regenerator memory regenerator) private pure returns (bool) {
-    return regenerator.regenerationScore.score >= LIMIT_REGENERATION_SCORE_TO_POOL;
   }
 
   /**
@@ -236,13 +229,17 @@ contract RegeneratorRules is Callable {
   }
 
   /**
-   * @dev Calculate blocks to next era
+   * @notice Calculate blocks to next era
    * @return uint256 Return the amount of blocks to next era
    */
   function nextEraIn() public view returns (uint256) {
     return uint256(regeneratorPool.nextEraIn(regeneratorPoolEra()));
   }
 
+  /**
+   * @notice Total regeneration area
+   * @return uint256 Return the regeneration area [m²]
+   */
   function regenerationTotalArea() public view returns (uint256) {
     return regenerationArea;
   }

--- a/contracts/ResearcherRules.sol
+++ b/contracts/ResearcherRules.sol
@@ -246,8 +246,9 @@ contract ResearcherRules is Callable, Invitable {
    * @dev Allows a researcher to attempt to publish an calculatorItem to users calculate their degradation
    * @notice One calculatorItem per research
    * @param title CalculatorItem title
+   * @param unit Unit of the item. Exapmle: liters, kwh, kg
    * @param justification Item result justification
-   * @param carbonImpact Tons of carbon [t]
+   * @param carbonImpact Kg of carbon [kg]
    */
   function addCalculatorItem(
     string memory title,

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -971,7 +971,7 @@ describe("InspectionRules", () => {
 
                       const biodiversityResultValue = {
                         categoryId: 2,
-                        indicator: 501,
+                        indicator: 130,
                       };
 
                       await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
@@ -988,12 +988,12 @@ describe("InspectionRules", () => {
                     beforeEach(async () => {
                       const treesResultValue = {
                         categoryId: 1,
-                        indicator: 1001,
+                        indicator: 5801,
                       };
 
                       const biodiversityResultValue = {
                         categoryId: 2,
-                        indicator: 201,
+                        indicator: 101,
                       };
 
                       await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
@@ -1010,12 +1010,12 @@ describe("InspectionRules", () => {
                     beforeEach(async () => {
                       const treesResultValue = {
                         categoryId: 1,
-                        indicator: 101,
+                        indicator: 1001,
                       };
 
                       const biodiversityResultValue = {
                         categoryId: 2,
-                        indicator: 101,
+                        indicator: 51,
                       };
 
                       await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
@@ -1032,12 +1032,12 @@ describe("InspectionRules", () => {
                     beforeEach(async () => {
                       const treesResultValue = {
                         categoryId: 1,
-                        indicator: 15,
+                        indicator: 500,
                       };
 
                       const biodiversityResultValue = {
                         categoryId: 2,
-                        indicator: 51,
+                        indicator: 21,
                       };
 
                       await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
@@ -1054,12 +1054,12 @@ describe("InspectionRules", () => {
                     beforeEach(async () => {
                       const treesResultValue = {
                         categoryId: 1,
-                        indicator: 5,
+                        indicator: 50,
                       };
 
                       const biodiversityResultValue = {
                         categoryId: 2,
-                        indicator: 30,
+                        indicator: 10,
                       };
 
                       await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -112,7 +112,7 @@ describe("InspectionRules", () => {
     await communityRules.connect(from).addInvitation(inviter, invited, userType);
   };
 
-  const biomassResultValue = () => {
+  const treesResultValue = () => {
     return {
       categoryId: 1,
       indicator: 10,
@@ -136,10 +136,10 @@ describe("InspectionRules", () => {
     await instance.connect(from).acceptInspection(inspectionId);
   };
 
-  const realizeInspection = async (id, report, biomassResult, biodiversityResult, from) => {
+  const realizeInspection = async (id, report, treesResult, biodiversityResult, from) => {
     const proofPhoto = "proofPhoto";
 
-    await instance.connect(from).realizeInspection(id, proofPhoto, report, biomassResult, biodiversityResult);
+    await instance.connect(from).realizeInspection(id, proofPhoto, report, treesResult, biodiversityResult);
   };
 
   beforeEach(async () => {
@@ -279,7 +279,7 @@ describe("InspectionRules", () => {
           beforeEach(async () => {
             await acceptInspection(1, inspectorAddress);
 
-            const biomassResultValue = {
+            const treesResultValue = {
               categoryId: 1,
               indicator: 15,
             };
@@ -289,7 +289,7 @@ describe("InspectionRules", () => {
               indicator: 51,
             };
 
-            await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+            await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
           });
 
           context("when last request is recent", () => {
@@ -313,7 +313,7 @@ describe("InspectionRules", () => {
 
       context("when reached maximum inspections", () => {
         beforeEach(async () => {
-          const biomassResultValue = {
+          const treesResultValue = {
             categoryId: 1,
             indicator: 15,
           };
@@ -324,74 +324,74 @@ describe("InspectionRules", () => {
           };
 
           await acceptInspection(1, inspectorAddress);
-          await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+          await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(2, inspector2Address);
-          await realizeInspection(2, report, biomassResultValue, biodiversityResultValue, inspector2Address);
+          await realizeInspection(2, report, treesResultValue, biodiversityResultValue, inspector2Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(3, inspector3Address);
-          await realizeInspection(3, report, biomassResultValue, biodiversityResultValue, inspector3Address);
+          await realizeInspection(3, report, treesResultValue, biodiversityResultValue, inspector3Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(4, inspector4Address);
-          await realizeInspection(4, report, biomassResultValue, biodiversityResultValue, inspector4Address);
+          await realizeInspection(4, report, treesResultValue, biodiversityResultValue, inspector4Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(5, inspector5Address);
-          await realizeInspection(5, report, biomassResultValue, biodiversityResultValue, inspector5Address);
+          await realizeInspection(5, report, treesResultValue, biodiversityResultValue, inspector5Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(6, inspector6Address);
-          await realizeInspection(6, report, biomassResultValue, biodiversityResultValue, inspector6Address);
+          await realizeInspection(6, report, treesResultValue, biodiversityResultValue, inspector6Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(7, inspector7Address);
-          await realizeInspection(7, report, biomassResultValue, biodiversityResultValue, inspector7Address);
+          await realizeInspection(7, report, treesResultValue, biodiversityResultValue, inspector7Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(8, inspector8Address);
-          await realizeInspection(8, report, biomassResultValue, biodiversityResultValue, inspector8Address);
+          await realizeInspection(8, report, treesResultValue, biodiversityResultValue, inspector8Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(9, inspector9Address);
-          await realizeInspection(9, report, biomassResultValue, biodiversityResultValue, inspector9Address);
+          await realizeInspection(9, report, treesResultValue, biodiversityResultValue, inspector9Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(10, inspector10Address);
-          await realizeInspection(10, report, biomassResultValue, biodiversityResultValue, inspector10Address);
+          await realizeInspection(10, report, treesResultValue, biodiversityResultValue, inspector10Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(11, inspector11Address);
-          await realizeInspection(11, report, biomassResultValue, biodiversityResultValue, inspector11Address);
+          await realizeInspection(11, report, treesResultValue, biodiversityResultValue, inspector11Address);
 
           await advanceBlock(20);
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await advanceBlock(200);
           await acceptInspection(12, inspector12Address);
-          await realizeInspection(12, report, biomassResultValue, biodiversityResultValue, inspector12Address);
+          await realizeInspection(12, report, treesResultValue, biodiversityResultValue, inspector12Address);
         });
 
         it("should return error", async () => {
@@ -626,7 +626,7 @@ describe("InspectionRules", () => {
             context("when have finished last inspection", () => {
               beforeEach(async () => {
                 await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
-                await realizeInspection(1, "", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+                await realizeInspection(1, "", treesResultValue(), biodiversityResultValue(), inspectorAddress);
                 await acceptInspection(2, inspectorAddress);
               });
 
@@ -651,7 +651,7 @@ describe("InspectionRules", () => {
           beforeEach(async () => {
             await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
             await acceptInspection(1, inspectorAddress);
-            await realizeInspection(1, report, biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            await realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
             await advanceBlock(20);
 
@@ -713,7 +713,7 @@ describe("InspectionRules", () => {
 
               it("should return error message", async () => {
                 await expect(
-                  realizeInspection(1, report, biomassResultValue(), biodiversityResultValue(), inspectorAddress)
+                  realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), inspectorAddress)
                 ).to.be.revertedWith("Inspection Expired");
               });
             });
@@ -726,7 +726,7 @@ describe("InspectionRules", () => {
                       await realizeInspection(
                         1,
                         report,
-                        biomassResultValue(),
+                        treesResultValue(),
                         biodiversityResultValue(),
                         inspectorAddress
                       );
@@ -750,7 +750,7 @@ describe("InspectionRules", () => {
                       await realizeInspection(
                         1,
                         report,
-                        biomassResultValue(),
+                        treesResultValue(),
                         biodiversityResultValue(),
                         inspectorAddress
                       );
@@ -776,7 +776,7 @@ describe("InspectionRules", () => {
                       await realizeInspection(
                         1,
                         report,
-                        biomassResultValue(),
+                        treesResultValue(),
                         biodiversityResultValue(),
                         inspectorAddress
                       );
@@ -806,7 +806,7 @@ describe("InspectionRules", () => {
                       await realizeInspection(
                         1,
                         report,
-                        biomassResultValue(),
+                        treesResultValue(),
                         biodiversityResultValue(),
                         inspectorAddress
                       );
@@ -838,7 +838,7 @@ describe("InspectionRules", () => {
                       await realizeInspection(
                         1,
                         report,
-                        biomassResultValue(),
+                        treesResultValue(),
                         biodiversityResultValue(),
                         inspectorAddress
                       );
@@ -863,7 +863,7 @@ describe("InspectionRules", () => {
                     await realizeInspection(
                       1,
                       report,
-                      biomassResultValue(),
+                      treesResultValue(),
                       biodiversityResultValue(),
                       inspectorAddress
                     );
@@ -875,10 +875,10 @@ describe("InspectionRules", () => {
                     expect(inspection.status).to.equal(STATUS.inspected);
                   });
 
-                  it("should set inspectionsBiomassImpact", async () => {
-                    const inspectionsBiomassImpact = await instance.inspectionsBiomassImpact();
+                  it("should set inspectionsTreesImpact", async () => {
+                    const inspectionsTreesImpact = await instance.inspectionsTreesImpact();
 
-                    expect(inspectionsBiomassImpact).to.equal(10);
+                    expect(inspectionsTreesImpact).to.equal(10);
                   });
 
                   it("should set inspectionsBiodiversityImpact", async () => {
@@ -948,7 +948,7 @@ describe("InspectionRules", () => {
                 context("when check inspection regenerationIndex", () => {
                   context("when select REGENERATIVE_6", () => {
                     beforeEach(async () => {
-                      const biomassResultValue = {
+                      const treesResultValue = {
                         categoryId: 1,
                         indicator: 100001,
                       };
@@ -958,7 +958,7 @@ describe("InspectionRules", () => {
                         indicator: 1001,
                       };
 
-                      await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+                      await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
                     });
 
                     it("should add 64 regenerationScore to inspection", async () => {
@@ -970,7 +970,7 @@ describe("InspectionRules", () => {
 
                   context("when select REGENERATIVE_5", () => {
                     beforeEach(async () => {
-                      const biomassResultValue = {
+                      const treesResultValue = {
                         categoryId: 1,
                         indicator: 10001,
                       };
@@ -980,7 +980,7 @@ describe("InspectionRules", () => {
                         indicator: 501,
                       };
 
-                      await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+                      await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
                     });
 
                     it("should add 32 regenerationScore to inspection", async () => {
@@ -992,7 +992,7 @@ describe("InspectionRules", () => {
 
                   context("when select REGENERATIVE_4", () => {
                     beforeEach(async () => {
-                      const biomassResultValue = {
+                      const treesResultValue = {
                         categoryId: 1,
                         indicator: 1001,
                       };
@@ -1002,7 +1002,7 @@ describe("InspectionRules", () => {
                         indicator: 201,
                       };
 
-                      await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+                      await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
                     });
 
                     it("should add 16 regenerationScore to inspection", async () => {
@@ -1014,7 +1014,7 @@ describe("InspectionRules", () => {
 
                   context("when select REGENERATIVE_3", () => {
                     beforeEach(async () => {
-                      const biomassResultValue = {
+                      const treesResultValue = {
                         categoryId: 1,
                         indicator: 101,
                       };
@@ -1024,7 +1024,7 @@ describe("InspectionRules", () => {
                         indicator: 101,
                       };
 
-                      await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+                      await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
                     });
 
                     it("should add 4 regenerationScore to inspection", async () => {
@@ -1036,7 +1036,7 @@ describe("InspectionRules", () => {
 
                   context("when select REGENERATIVE_2", () => {
                     beforeEach(async () => {
-                      const biomassResultValue = {
+                      const treesResultValue = {
                         categoryId: 1,
                         indicator: 15,
                       };
@@ -1046,7 +1046,7 @@ describe("InspectionRules", () => {
                         indicator: 51,
                       };
 
-                      await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+                      await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
                     });
 
                     it("should add 2 regenerationScore to inspection", async () => {
@@ -1058,7 +1058,7 @@ describe("InspectionRules", () => {
 
                   context("when select REGENERATIVE_1", () => {
                     beforeEach(async () => {
-                      const biomassResultValue = {
+                      const treesResultValue = {
                         categoryId: 1,
                         indicator: 5,
                       };
@@ -1068,7 +1068,7 @@ describe("InspectionRules", () => {
                         indicator: 30,
                       };
 
-                      await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+                      await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
                     });
 
                     it("should add 1 regenerationScore to inspection", async () => {
@@ -1080,7 +1080,7 @@ describe("InspectionRules", () => {
 
                   context("when select NEUTRO", () => {
                     beforeEach(async () => {
-                      const biomassResultValue = {
+                      const treesResultValue = {
                         categoryId: 1,
                         indicator: 0,
                       };
@@ -1090,7 +1090,7 @@ describe("InspectionRules", () => {
                         indicator: 0,
                       };
 
-                      await realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress);
+                      await realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress);
                     });
 
                     it("should add 0 regenerationScore to inspection", async () => {
@@ -1102,8 +1102,8 @@ describe("InspectionRules", () => {
                 });
               });
 
-              context("when pass wrong biomassResult or biodiversity", () => {
-                const biomassResultValue = {
+              context("when pass wrong treesResult or biodiversity", () => {
+                const treesResultValue = {
                   categoryId: 10,
                   indicator: 1001,
                 };
@@ -1115,8 +1115,8 @@ describe("InspectionRules", () => {
 
                 it("should return error message", async () => {
                   await expect(
-                    realizeInspection(1, report, biomassResultValue, biodiversityResultValue, inspectorAddress)
-                  ).to.be.revertedWith("Invalid biomassResult or biodiversityResult");
+                    realizeInspection(1, report, treesResultValue, biodiversityResultValue, inspectorAddress)
+                  ).to.be.revertedWith("Invalid treesResult or biodiversityResult");
                 });
               });
             });
@@ -1130,7 +1130,7 @@ describe("InspectionRules", () => {
 
             it("should return error message", async () => {
               await expect(
-                realizeInspection(1, report, biomassResultValue(), biodiversityResultValue(), inspector2Address)
+                realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), inspector2Address)
               ).to.be.revertedWith("You have not accepted this inspection");
             });
           });
@@ -1139,7 +1139,7 @@ describe("InspectionRules", () => {
         context("when inspection is not accepted", () => {
           it("should return error message", async () => {
             await expect(
-              realizeInspection(1, report, biomassResultValue(), biodiversityResultValue(), inspectorAddress)
+              realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), inspectorAddress)
             ).to.be.revertedWith("Accept this inspection before");
           });
         });
@@ -1148,7 +1148,7 @@ describe("InspectionRules", () => {
       context("when inspection dont exists", () => {
         it("should return error message", async () => {
           await expect(
-            realizeInspection(1, report, biomassResultValue(), biodiversityResultValue(), inspectorAddress)
+            realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), inspectorAddress)
           ).to.be.revertedWith("Accept this inspection before");
         });
       });
@@ -1161,7 +1161,7 @@ describe("InspectionRules", () => {
         await acceptInspection(1, inspectorAddress);
 
         await expect(
-          realizeInspection(1, report, biomassResultValue(), biodiversityResultValue(), regeneratorAddress)
+          realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), regeneratorAddress)
         ).to.be.revertedWith("Please register as inspector");
       });
     });
@@ -1194,7 +1194,7 @@ describe("InspectionRules", () => {
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(1, inspectorAddress);
-          await realizeInspection(1, report, biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+          await realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), inspectorAddress);
         });
 
         context("when receive 1 validation", () => {
@@ -1227,13 +1227,13 @@ describe("InspectionRules", () => {
               expect(validation2.validator).to.equal(validator2Address.address);
             });
 
-            it("decrement inspectionsBiomassImpact", async () => {
-              const inspectionsBiomassImpact = await instance.inspectionsBiomassImpact();
+            it("decrement inspectionsTreesImpact", async () => {
+              const inspectionsTreesImpact = await instance.inspectionsTreesImpact();
 
-              expect(inspectionsBiomassImpact).to.equal(0);
+              expect(inspectionsTreesImpact).to.equal(0);
             });
 
-            it("decrement inspectionsBiomassImpact", async () => {
+            it("decrement inspectionsTreesImpact", async () => {
               const inspectionsBiodiversityImpact = await instance.inspectionsBiodiversityImpact();
 
               expect(inspectionsBiodiversityImpact).to.equal(0);
@@ -1310,7 +1310,7 @@ describe("InspectionRules", () => {
           await requestInspection(regeneratorAddress);
           await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           await acceptInspection(1, inspectorAddress);
-          await realizeInspection(1, report, biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+          await realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
           await advanceBlock(regeneratorPoolArgs.blocksPerEra);
         });

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -860,13 +860,7 @@ describe("InspectionRules", () => {
 
                 context("when check inspection", () => {
                   beforeEach(async () => {
-                    await realizeInspection(
-                      1,
-                      report,
-                      treesResultValue(),
-                      biodiversityResultValue(),
-                      inspectorAddress
-                    );
+                    await realizeInspection(1, report, treesResultValue(), biodiversityResultValue(), inspectorAddress);
                   });
 
                   it("should change inspection status to INSPECTED", async () => {

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -68,7 +68,7 @@ describe("InspectionRules", () => {
   };
 
   const addRegenerator = async (name, from) => {
-    await regeneratorRules.connect(from).addRegenerator(10, name, "photoURL", coordinates());
+    await regeneratorRules.connect(from).addRegenerator(1000, name, "photoURL", coordinates());
   };
 
   const coordinates = () => {

--- a/test/RegenerationCreditImpact.test.js
+++ b/test/RegenerationCreditImpact.test.js
@@ -17,7 +17,7 @@ describe("RegenerationCreditImpact", () => {
     inspector3Address,
     inspector4Address,
     inspector5Address;
-  let biomassIndicatorValue = 10;
+  let treesIndicatorValue = 10;
   let biodiversityIndicatorValue = 10;
 
   const addRegenerator = async (name, from, _coordinates = []) => {
@@ -50,10 +50,10 @@ describe("RegenerationCreditImpact", () => {
     ];
   };
 
-  const biomassResultValue = () => {
+  const treesResultValue = () => {
     return {
       categoryId: 1,
-      indicator: biomassIndicatorValue,
+      indicator: treesIndicatorValue,
     };
   };
 
@@ -64,10 +64,10 @@ describe("RegenerationCreditImpact", () => {
     };
   };
 
-  const realizeInspection = async (id, report, biomassResult, biodiversityResult, from) => {
+  const realizeInspection = async (id, report, treesResult, biodiversityResult, from) => {
     const proofPhoto = "proofPhoto";
 
-    await inspectionRules.connect(from).realizeInspection(id, proofPhoto, report, biomassResult, biodiversityResult);
+    await inspectionRules.connect(from).realizeInspection(id, proofPhoto, report, treesResult, biodiversityResult);
   };
 
   beforeEach(async () => {
@@ -115,7 +115,7 @@ describe("RegenerationCreditImpact", () => {
     await regeneratorRules.newAllowedCaller(owner);
   });
 
-  describe("totalCarbonImpact", () => {
+  describe("totalTreesImpact", () => {
     beforeEach(async () => {
       await invitationRules.onlyOwnerInvite(regeneratorAddress, userTypes.Regenerator);
       await invitationRules.onlyOwnerInvite(inspectorAddress, userTypes.Inspector);
@@ -125,15 +125,15 @@ describe("RegenerationCreditImpact", () => {
     });
 
     context("when do not have inspections", async () => {
-      it("totalCarbonImpact must be 0", async () => {
-        const totalCarbonImpact = await instance.totalCarbonImpact();
+      it("totalTreesImpact must be 0", async () => {
+        const totalTreesImpact = await instance.totalTreesImpact();
 
-        expect(totalCarbonImpact).to.equal(0);
+        expect(totalTreesImpact).to.equal(0);
       });
     });
 
     context("when have inspections", () => {
-      context("when inspectionsBiomassImpact is 0", () => {
+      context("when inspectionsTreesImpact is 0", () => {
         beforeEach(async () => {
           await inspectionRules.connect(regeneratorAddress).requestInspection();
 
@@ -141,19 +141,19 @@ describe("RegenerationCreditImpact", () => {
 
           await inspectionRules.connect(inspectorAddress).acceptInspection(1);
 
-          biomassIndicatorValue = 0;
+          treesIndicatorValue = 0;
 
-          await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+          await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
         });
 
-        it("totalCarbonImpact must be 0", async () => {
-          const totalCarbonImpact = await instance.totalCarbonImpact();
+        it("totalTreesImpact must be 0", async () => {
+          const totalTreesImpact = await instance.totalTreesImpact();
 
-          expect(totalCarbonImpact).to.equal(0);
+          expect(totalTreesImpact).to.equal(0);
         });
       });
 
-      context("when inspectionsBiomassImpact is not 0", () => {
+      context("when inspectionsTreesImpact is not 0", () => {
         beforeEach(async () => {
           await inspectionRules.connect(regeneratorAddress).requestInspection();
 
@@ -163,31 +163,31 @@ describe("RegenerationCreditImpact", () => {
         });
 
         context("when have 1 inspection", () => {
-          context("when inspection biomass impact is 10", () => {
+          context("when inspection trees impact is 10", () => {
             beforeEach(async () => {
-              biomassIndicatorValue = 10;
+              treesIndicatorValue = 10;
 
-              await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
             });
 
-            it("must returnstotalCarbonImpact equal 5", async () => {
-              const totalCarbonImpact = await instance.totalCarbonImpact();
+            it("must returnstotalTreesImpact equal 10", async () => {
+              const totalTreesImpact = await instance.totalTreesImpact();
 
-              expect(totalCarbonImpact).to.equal(5);
+              expect(totalTreesImpact).to.equal(10);
             });
           });
 
           context("when inspection biomass impact is 25", () => {
             beforeEach(async () => {
-              biomassIndicatorValue = 32;
+              treesIndicatorValue = 32;
 
-              await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
             });
 
-            it("must returnstotalCarbonImpact equal 16", async () => {
-              const totalCarbonImpact = await instance.totalCarbonImpact();
+            it("must returnstotalTreesImpact equal 32", async () => {
+              const totalTreesImpact = await instance.totalTreesImpact();
 
-              expect(totalCarbonImpact).to.equal(16);
+              expect(totalTreesImpact).to.equal(32);
             });
           });
         });
@@ -226,26 +226,26 @@ describe("RegenerationCreditImpact", () => {
             await inspectionRules.connect(inspector4Address).acceptInspection(4);
             await inspectionRules.connect(inspector5Address).acceptInspection(5);
 
-            biomassIndicatorValue = 32;
-            await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            treesIndicatorValue = 32;
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
-            biomassIndicatorValue = 0;
-            await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+            treesIndicatorValue = 0;
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
-            biomassIndicatorValue = 100;
-            await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+            treesIndicatorValue = 100;
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
 
-            biomassIndicatorValue = 10;
-            await realizeInspection(4, "report", biomassResultValue(), biodiversityResultValue(), inspector4Address);
+            treesIndicatorValue = 10;
+            await realizeInspection(4, "report", treesResultValue(), biodiversityResultValue(), inspector4Address);
 
-            biomassIndicatorValue = 32;
-            await realizeInspection(5, "report", biomassResultValue(), biodiversityResultValue(), inspector5Address);
+            treesIndicatorValue = 32;
+            await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
           });
 
-          it("must returnstotalCarbonImpact equal 85", async () => {
-            const totalCarbonImpact = await instance.totalCarbonImpact();
+          it("must returnstotalTreesImpact equal 170", async () => {
+            const totalTreesImpact = await instance.totalTreesImpact();
 
-            expect(totalCarbonImpact).to.equal(85);
+            expect(totalTreesImpact).to.equal(170);
           });
         });
 
@@ -263,8 +263,8 @@ describe("RegenerationCreditImpact", () => {
             await addInspector("Inspector B", inspector2Address);
             await addInspector("Inspector C", inspector3Address);
 
-            biomassIndicatorValue = 32;
-            await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            treesIndicatorValue = 32;
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
             await inspectionRules.connect(regeneratorAddress).requestInspection();
             await inspectionRules.connect(regenerator2Address).requestInspection();
@@ -274,17 +274,17 @@ describe("RegenerationCreditImpact", () => {
             await inspectionRules.connect(inspector2Address).acceptInspection(2);
             await inspectionRules.connect(inspector3Address).acceptInspection(3);
 
-            biomassIndicatorValue = 0;
-            await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+            treesIndicatorValue = 0;
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
-            biomassIndicatorValue = 100;
-            await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+            treesIndicatorValue = 100;
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
           });
 
-          it("must returnstotalCarbonImpact equal 44", async () => {
-            const totalCarbonImpact = await instance.totalCarbonImpact();
+          it("must returnstotalTreesImpact equal 88", async () => {
+            const totalTreesImpact = await instance.totalTreesImpact();
 
-            expect(totalCarbonImpact).to.equal(44);
+            expect(totalTreesImpact).to.equal(88);
           });
         });
 
@@ -303,8 +303,8 @@ describe("RegenerationCreditImpact", () => {
         //     await addInspector("Inspector B", inspector2Address);
         //     await addInspector("Inspector C", inspector3Address);
 
-        //     biomassIndicatorValue = 32;
-        //     await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+        //     treesIndicatorValue = 32;
+        //     await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
         //     await inspectionRules.connect(regeneratorAddress).requestInspection();
         //     await inspectionRules.connect(regenerator2Address).requestInspection();
@@ -314,17 +314,17 @@ describe("RegenerationCreditImpact", () => {
         //     await inspectionRules.connect(inspector2Address).acceptInspection(2);
         //     await inspectionRules.connect(inspector3Address).acceptInspection(3);
 
-        //     biomassIndicatorValue = 0;
-        //     await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+        //     treesIndicatorValue = 0;
+        //     await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
-        //     biomassIndicatorValue = 100;
-        //     await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+        //     treesIndicatorValue = 100;
+        //     await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
         //   });
 
-        //   it("must returnstotalCarbonImpact equal 44", async () => {
-        //     const totalCarbonImpact = await instance.totalCarbonImpact();
+        //   it("must returnstotalTreesImpact equal 44", async () => {
+        //     const totalTreesImpact = await instance.totalTreesImpact();
 
-        //     expect(totalCarbonImpact).to.equal(44);
+        //     expect(totalTreesImpact).to.equal(44);
         //   });
         // });
       });
@@ -359,7 +359,7 @@ describe("RegenerationCreditImpact", () => {
 
           biodiversityIndicatorValue = 0;
 
-          await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+          await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
         });
 
         it("totalBiodiversityImpact must be 0", async () => {
@@ -383,7 +383,7 @@ describe("RegenerationCreditImpact", () => {
             beforeEach(async () => {
               biodiversityIndicatorValue = 10;
 
-              await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
             });
 
             it("must returns totalBiodiversityImpact equal 10", async () => {
@@ -397,7 +397,7 @@ describe("RegenerationCreditImpact", () => {
             beforeEach(async () => {
               biodiversityIndicatorValue = 32;
 
-              await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
             });
 
             it("must returns totalBiodiversityImpact equal 32", async () => {
@@ -443,19 +443,19 @@ describe("RegenerationCreditImpact", () => {
             await inspectionRules.connect(inspector5Address).acceptInspection(5);
 
             biodiversityIndicatorValue = 32;
-            await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
             biodiversityIndicatorValue = 0;
-            await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
             biodiversityIndicatorValue = 100;
-            await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
 
             biodiversityIndicatorValue = 10;
-            await realizeInspection(4, "report", biomassResultValue(), biodiversityResultValue(), inspector4Address);
+            await realizeInspection(4, "report", treesResultValue(), biodiversityResultValue(), inspector4Address);
 
             biodiversityIndicatorValue = 32;
-            await realizeInspection(5, "report", biomassResultValue(), biodiversityResultValue(), inspector5Address);
+            await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
           });
 
           it("must returns totalBiodiversityImpact equal 170", async () => {
@@ -480,7 +480,7 @@ describe("RegenerationCreditImpact", () => {
             await addInspector("Inspector C", inspector3Address);
 
             biodiversityIndicatorValue = 32;
-            await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
             await inspectionRules.connect(regeneratorAddress).requestInspection();
             await inspectionRules.connect(regenerator2Address).requestInspection();
@@ -491,10 +491,10 @@ describe("RegenerationCreditImpact", () => {
             await inspectionRules.connect(inspector3Address).acceptInspection(3);
 
             biodiversityIndicatorValue = 0;
-            await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
             biodiversityIndicatorValue = 100;
-            await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
           });
 
           it("must returns totalBiodiversityImpact equal 88", async () => {
@@ -520,7 +520,7 @@ describe("RegenerationCreditImpact", () => {
         //     await addInspector("Inspector C", inspector3Address);
 
         //     biodiversityIndicatorValue = 32;
-        //     await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+        //     await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
         //     await inspectionRules.connect(regeneratorAddress).requestInspection();
         //     await inspectionRules.connect(regenerator2Address).requestInspection();
@@ -531,16 +531,16 @@ describe("RegenerationCreditImpact", () => {
         //     await inspectionRules.connect(inspector3Address).acceptInspection(3);
 
         //     biodiversityIndicatorValue = 0;
-        //     await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+        //     await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
         //     biodiversityIndicatorValue = 100;
-        //     await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+        //     await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
         //   });
 
-        //   it("must returnstotalCarbonImpact equal 44", async () => {
-        //     const totalCarbonImpact = await instance.totalCarbonImpact();
+        //   it("must returnstotalTreesImpact equal 44", async () => {
+        //     const totalTreesImpact = await instance.totalTreesImpact();
 
-        //     expect(totalCarbonImpact).to.equal(44);
+        //     expect(totalTreesImpact).to.equal(44);
         //   });
         // });
       });
@@ -579,7 +579,7 @@ describe("RegenerationCreditImpact", () => {
     });
   });
 
-  describe("tokenCarbonImpact", () => {
+  describe("tokenTreesImpact", () => {
     beforeEach(async () => {
       await invitationRules.onlyOwnerInvite(regeneratorAddress, userTypes.Regenerator);
       await invitationRules.onlyOwnerInvite(inspectorAddress, userTypes.Inspector);
@@ -589,15 +589,15 @@ describe("RegenerationCreditImpact", () => {
     });
 
     context("when do not have inspections", async () => {
-      it("tokenCarbonImpact must be 0", async () => {
-        const tokenCarbonImpact = await instance.tokenCarbonImpact();
+      it("tokenTreesImpact must be 0", async () => {
+        const tokenTreesImpact = await instance.tokenTreesImpact();
 
-        expect(tokenCarbonImpact).to.equal(0);
+        expect(tokenTreesImpact).to.equal(0);
       });
     });
 
     context("when have inspections", () => {
-      context("when inspectionsBiomassImpact is 0", () => {
+      context("when inspectionsTreesImpact is 0", () => {
         beforeEach(async () => {
           await inspectionRules.connect(regeneratorAddress).requestInspection();
 
@@ -605,19 +605,19 @@ describe("RegenerationCreditImpact", () => {
 
           await inspectionRules.connect(inspectorAddress).acceptInspection(1);
 
-          biomassIndicatorValue = 0;
+          treesIndicatorValue = 0;
 
-          await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+          await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
         });
 
-        it("tokenCarbonImpact must be 0", async () => {
-          const tokenCarbonImpact = await instance.tokenCarbonImpact();
+        it("tokenTreesImpact must be 0", async () => {
+          const tokenTreesImpact = await instance.tokenTreesImpact();
 
-          expect(tokenCarbonImpact).to.equal(0);
+          expect(tokenTreesImpact).to.equal(0);
         });
       });
 
-      context("when inspectionsBiomassImpact is not 0", () => {
+      context("when inspectionsTreesImpact is not 0", () => {
         beforeEach(async () => {
           await inspectionRules.connect(regeneratorAddress).requestInspection();
 
@@ -629,20 +629,20 @@ describe("RegenerationCreditImpact", () => {
         context("when have 1 inspection", () => {
           context("when inspection biomass impact is 10", () => {
             beforeEach(async () => {
-              biomassIndicatorValue = 10;
+              treesIndicatorValue = 10;
             });
 
             context("when do not have tokens totalLocked_", () => {
               beforeEach(async () => {
-                biomassIndicatorValue = 10;
+                treesIndicatorValue = 10;
 
-                await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+                await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
-              it("must returns tokenCarbonImpact equal 333333", async () => {
-                const tokenCarbonImpact = await instance.tokenCarbonImpact();
+              it("must returns tokenTreesImpact equal 666666", async () => {
+                const tokenTreesImpact = await instance.tokenTreesImpact();
 
-                expect(tokenCarbonImpact).to.equal(333333);
+                expect(tokenTreesImpact).to.equal(666666);
               });
             });
 
@@ -651,30 +651,30 @@ describe("RegenerationCreditImpact", () => {
                 await regenerationCredit.addContractPool(ZERO_ADDRESS, 300000000000000000000000000n);
                 await regenerationCredit.addContractPool(ZERO_ADDRESS, 300000000000000000000000000n);
 
-                biomassIndicatorValue = 10;
+                treesIndicatorValue = 10;
 
-                await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+                await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
-              it("must returns tokenCarbonImpact equal 555555", async () => {
-                const tokenCarbonImpact = await instance.tokenCarbonImpact();
+              it("must returns tokenTreesImpact equal 1111111", async () => {
+                const tokenTreesImpact = await instance.tokenTreesImpact();
 
-                expect(tokenCarbonImpact).to.equal(555555);
+                expect(tokenTreesImpact).to.equal(1111111);
               });
             });
           });
 
           context("when inspection biomass impact is 25", () => {
             beforeEach(async () => {
-              biomassIndicatorValue = 32;
+              treesIndicatorValue = 32;
 
-              await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
             });
 
-            it("must returnstotalCarbonImpact equal 1066666", async () => {
-              const tokenCarbonImpact = await instance.tokenCarbonImpact();
+            it("must returnstotalTreesImpact equal 2133333", async () => {
+              const tokenTreesImpact = await instance.tokenTreesImpact();
 
-              expect(tokenCarbonImpact).to.equal(1066666);
+              expect(tokenTreesImpact).to.equal(2133333);
             });
           });
         });
@@ -713,26 +713,26 @@ describe("RegenerationCreditImpact", () => {
             await inspectionRules.connect(inspector4Address).acceptInspection(4);
             await inspectionRules.connect(inspector5Address).acceptInspection(5);
 
-            biomassIndicatorValue = 32;
-            await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            treesIndicatorValue = 32;
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
-            biomassIndicatorValue = 0;
-            await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+            treesIndicatorValue = 0;
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
-            biomassIndicatorValue = 100;
-            await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+            treesIndicatorValue = 100;
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
 
-            biomassIndicatorValue = 10;
-            await realizeInspection(4, "report", biomassResultValue(), biodiversityResultValue(), inspector4Address);
+            treesIndicatorValue = 10;
+            await realizeInspection(4, "report", treesResultValue(), biodiversityResultValue(), inspector4Address);
 
-            biomassIndicatorValue = 32;
-            await realizeInspection(5, "report", biomassResultValue(), biodiversityResultValue(), inspector5Address);
+            treesIndicatorValue = 32;
+            await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
           });
 
-          it("must returns tokenCarbonImpact equal 5666666", async () => {
-            const tokenCarbonImpact = await instance.tokenCarbonImpact();
+          it("must returns tokenTreesImpact equal 11333333", async () => {
+            const tokenTreesImpact = await instance.tokenTreesImpact();
 
-            expect(tokenCarbonImpact).to.equal(5666666);
+            expect(tokenTreesImpact).to.equal(11333333);
           });
         });
 
@@ -750,8 +750,8 @@ describe("RegenerationCreditImpact", () => {
             await addInspector("Inspector B", inspector2Address);
             await addInspector("Inspector C", inspector3Address);
 
-            biomassIndicatorValue = 32;
-            await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            treesIndicatorValue = 32;
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
             await inspectionRules.connect(regeneratorAddress).requestInspection();
             await inspectionRules.connect(regenerator2Address).requestInspection();
@@ -761,17 +761,17 @@ describe("RegenerationCreditImpact", () => {
             await inspectionRules.connect(inspector2Address).acceptInspection(2);
             await inspectionRules.connect(inspector3Address).acceptInspection(3);
 
-            biomassIndicatorValue = 0;
-            await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+            treesIndicatorValue = 0;
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
-            biomassIndicatorValue = 100;
-            await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+            treesIndicatorValue = 100;
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
           });
 
-          it("must returns tokenCarbonImpact equal 2933333", async () => {
-            const tokenCarbonImpact = await instance.tokenCarbonImpact();
+          it("must returns tokenTreesImpact equal 5866666", async () => {
+            const tokenTreesImpact = await instance.tokenTreesImpact();
 
-            expect(tokenCarbonImpact).to.equal(2933333);
+            expect(tokenTreesImpact).to.equal(5866666);
           });
         });
 
@@ -790,8 +790,8 @@ describe("RegenerationCreditImpact", () => {
         //     await addInspector("Inspector B", inspector2Address);
         //     await addInspector("Inspector C", inspector3Address);
 
-        //     biomassIndicatorValue = 32;
-        //     await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+        //     treesIndicatorValue = 32;
+        //     await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
         //     await inspectionRules.connect(regeneratorAddress).requestInspection();
         //     await inspectionRules.connect(regenerator2Address).requestInspection();
@@ -801,17 +801,17 @@ describe("RegenerationCreditImpact", () => {
         //     await inspectionRules.connect(inspector2Address).acceptInspection(2);
         //     await inspectionRules.connect(inspector3Address).acceptInspection(3);
 
-        //     biomassIndicatorValue = 0;
-        //     await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+        //     treesIndicatorValue = 0;
+        //     await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
-        //     biomassIndicatorValue = 100;
-        //     await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+        //     treesIndicatorValue = 100;
+        //     await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
         //   });
 
-        //   it("must returnstotalCarbonImpact equal 44", async () => {
-        //     const totalCarbonImpact = await instance.totalCarbonImpact();
+        //   it("must returnstotalTreesImpact equal 44", async () => {
+        //     const totalTreesImpact = await instance.totalTreesImpact();
 
-        //     expect(totalCarbonImpact).to.equal(44);
+        //     expect(totalTreesImpact).to.equal(44);
         //   });
         // });
       });
@@ -846,7 +846,7 @@ describe("RegenerationCreditImpact", () => {
 
           biodiversityIndicatorValue = 0;
 
-          await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+          await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
         });
 
         it("tokenBiodiversityImpact must be 0", async () => {
@@ -871,7 +871,7 @@ describe("RegenerationCreditImpact", () => {
               beforeEach(async () => {
                 biodiversityIndicatorValue = 10;
 
-                await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+                await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
               it("must returns tokenBiodiversityImpact equal 666666", async () => {
@@ -888,7 +888,7 @@ describe("RegenerationCreditImpact", () => {
 
                 biodiversityIndicatorValue = 10;
 
-                await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+                await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
               it("must returns tokenBiodiversityImpact equal 1111111", async () => {
@@ -903,7 +903,7 @@ describe("RegenerationCreditImpact", () => {
             beforeEach(async () => {
               biodiversityIndicatorValue = 32;
 
-              await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
             });
 
             it("must returns tokenBiodiversityImpact equal 2133333", async () => {
@@ -949,19 +949,19 @@ describe("RegenerationCreditImpact", () => {
             await inspectionRules.connect(inspector5Address).acceptInspection(5);
 
             biodiversityIndicatorValue = 32;
-            await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
             biodiversityIndicatorValue = 0;
-            await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
             biodiversityIndicatorValue = 100;
-            await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
 
             biodiversityIndicatorValue = 10;
-            await realizeInspection(4, "report", biomassResultValue(), biodiversityResultValue(), inspector4Address);
+            await realizeInspection(4, "report", treesResultValue(), biodiversityResultValue(), inspector4Address);
 
             biodiversityIndicatorValue = 32;
-            await realizeInspection(5, "report", biomassResultValue(), biodiversityResultValue(), inspector5Address);
+            await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
           });
 
           it("must returns tokenBiodiversityImpact equal 11333333", async () => {
@@ -986,7 +986,7 @@ describe("RegenerationCreditImpact", () => {
             await addInspector("Inspector C", inspector3Address);
 
             biodiversityIndicatorValue = 32;
-            await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
             await inspectionRules.connect(regeneratorAddress).requestInspection();
             await inspectionRules.connect(regenerator2Address).requestInspection();
@@ -997,10 +997,10 @@ describe("RegenerationCreditImpact", () => {
             await inspectionRules.connect(inspector3Address).acceptInspection(3);
 
             biodiversityIndicatorValue = 0;
-            await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
             biodiversityIndicatorValue = 100;
-            await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
           });
 
           it("must returns tokenBiodiversityImpact equal 5866666", async () => {
@@ -1026,7 +1026,7 @@ describe("RegenerationCreditImpact", () => {
         //     await addInspector("Inspector C", inspector3Address);
 
         //     biodiversityIndicatorValue = 32;
-        //     await realizeInspection(1, "report", biomassResultValue(), biodiversityResultValue(), inspectorAddress);
+        //     await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
 
         //     await inspectionRules.connect(regeneratorAddress).requestInspection();
         //     await inspectionRules.connect(regenerator2Address).requestInspection();
@@ -1037,16 +1037,16 @@ describe("RegenerationCreditImpact", () => {
         //     await inspectionRules.connect(inspector3Address).acceptInspection(3);
 
         //     biodiversityIndicatorValue = 0;
-        //     await realizeInspection(2, "report", biomassResultValue(), biodiversityResultValue(), inspector2Address);
+        //     await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
 
         //     biodiversityIndicatorValue = 100;
-        //     await realizeInspection(3, "report", biomassResultValue(), biodiversityResultValue(), inspector3Address);
+        //     await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
         //   });
 
-        //   it("must returnstotalCarbonImpact equal 44", async () => {
-        //     const totalCarbonImpact = await instance.totalCarbonImpact();
+        //   it("must returnstotalTreesImpact equal 44", async () => {
+        //     const totalTreesImpact = await instance.totalTreesImpact();
 
-        //     expect(totalCarbonImpact).to.equal(44);
+        //     expect(totalTreesImpact).to.equal(44);
         //   });
         // });
       });

--- a/test/RegenerationCreditImpact.test.js
+++ b/test/RegenerationCreditImpact.test.js
@@ -755,7 +755,7 @@ describe("RegenerationCreditImpact", () => {
     });
   });
 
-  describe("tokenTreesImpact", () => {
+  describe("treesPerToken", () => {
     beforeEach(async () => {
       await invitationRules.onlyOwnerInvite(regeneratorAddress, userTypes.Regenerator);
       await invitationRules.onlyOwnerInvite(inspectorAddress, userTypes.Inspector);
@@ -765,10 +765,10 @@ describe("RegenerationCreditImpact", () => {
     });
 
     context("when do not have inspections", async () => {
-      it("tokenTreesImpact must be 0", async () => {
-        const tokenTreesImpact = await instance.tokenTreesImpact();
+      it("treesPerToken must be 0", async () => {
+        const treesPerToken = await instance.treesPerToken();
 
-        expect(tokenTreesImpact).to.equal(0);
+        expect(treesPerToken).to.equal(0);
       });
     });
 
@@ -786,10 +786,10 @@ describe("RegenerationCreditImpact", () => {
           await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
         });
 
-        it("tokenTreesImpact must be 0", async () => {
-          const tokenTreesImpact = await instance.tokenTreesImpact();
+        it("treesPerToken must be 0", async () => {
+          const treesPerToken = await instance.treesPerToken();
 
-          expect(tokenTreesImpact).to.equal(0);
+          expect(treesPerToken).to.equal(0);
         });
       });
 
@@ -815,10 +815,10 @@ describe("RegenerationCreditImpact", () => {
                 await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
-              it("must returns tokenTreesImpact equal 666666", async () => {
-                const tokenTreesImpact = await instance.tokenTreesImpact();
+              it("must returns treesPerToken equal 666666", async () => {
+                const treesPerToken = await instance.treesPerToken();
 
-                expect(tokenTreesImpact).to.equal(666666);
+                expect(treesPerToken).to.equal(666666);
               });
             });
 
@@ -832,10 +832,10 @@ describe("RegenerationCreditImpact", () => {
                 await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
-              it("must returns tokenTreesImpact equal 1111111", async () => {
-                const tokenTreesImpact = await instance.tokenTreesImpact();
+              it("must returns treesPerToken equal 1111111", async () => {
+                const treesPerToken = await instance.treesPerToken();
 
-                expect(tokenTreesImpact).to.equal(1111111);
+                expect(treesPerToken).to.equal(1111111);
               });
             });
           });
@@ -848,9 +848,9 @@ describe("RegenerationCreditImpact", () => {
             });
 
             it("must returnstotalTreesImpact equal 2133333", async () => {
-              const tokenTreesImpact = await instance.tokenTreesImpact();
+              const treesPerToken = await instance.treesPerToken();
 
-              expect(tokenTreesImpact).to.equal(2133333);
+              expect(treesPerToken).to.equal(2133333);
             });
           });
         });
@@ -905,10 +905,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
           });
 
-          it("must returns tokenTreesImpact equal 11333333", async () => {
-            const tokenTreesImpact = await instance.tokenTreesImpact();
+          it("must returns treesPerToken equal 11333333", async () => {
+            const treesPerToken = await instance.treesPerToken();
 
-            expect(tokenTreesImpact).to.equal(11333333);
+            expect(treesPerToken).to.equal(11333333);
           });
         });
 
@@ -944,10 +944,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
           });
 
-          it("must returns tokenTreesImpact equal 5866666", async () => {
-            const tokenTreesImpact = await instance.tokenTreesImpact();
+          it("must returns treesPerToken equal 5866666", async () => {
+            const treesPerToken = await instance.treesPerToken();
 
-            expect(tokenTreesImpact).to.equal(5866666);
+            expect(treesPerToken).to.equal(5866666);
           });
         });
 
@@ -994,7 +994,7 @@ describe("RegenerationCreditImpact", () => {
     });
   });
 
-  describe("tokenCarbonImpact", () => {
+  describe("carbonPerToken", () => {
     beforeEach(async () => {
       await invitationRules.onlyOwnerInvite(regeneratorAddress, userTypes.Regenerator);
       await invitationRules.onlyOwnerInvite(inspectorAddress, userTypes.Inspector);
@@ -1004,10 +1004,10 @@ describe("RegenerationCreditImpact", () => {
     });
 
     context("when do not have inspections", async () => {
-      it("tokenCarbonImpact must be 0", async () => {
-        const tokenCarbonImpact = await instance.tokenCarbonImpact();
+      it("carbonPerToken must be 0", async () => {
+        const carbonPerToken = await instance.carbonPerToken();
 
-        expect(tokenCarbonImpact).to.equal(0);
+        expect(carbonPerToken).to.equal(0);
       });
     });
 
@@ -1025,10 +1025,10 @@ describe("RegenerationCreditImpact", () => {
           await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
         });
 
-        it("tokenCarbonImpact must be 0", async () => {
-          const tokenCarbonImpact = await instance.tokenCarbonImpact();
+        it("carbonPerToken must be 0", async () => {
+          const carbonPerToken = await instance.carbonPerToken();
 
-          expect(tokenCarbonImpact).to.equal(0);
+          expect(carbonPerToken).to.equal(0);
         });
       });
 
@@ -1054,10 +1054,10 @@ describe("RegenerationCreditImpact", () => {
                 await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
-              it("must returns tokenCarbonImpact equal 66666666", async () => {
-                const tokenCarbonImpact = await instance.tokenCarbonImpact();
+              it("must returns carbonPerToken equal 66666666", async () => {
+                const carbonPerToken = await instance.carbonPerToken();
 
-                expect(tokenCarbonImpact).to.equal(66666666);
+                expect(carbonPerToken).to.equal(66666666);
               });
             });
 
@@ -1071,10 +1071,10 @@ describe("RegenerationCreditImpact", () => {
                 await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
-              it("must returns tokenCarbonImpact equal 111111111", async () => {
-                const tokenCarbonImpact = await instance.tokenCarbonImpact();
+              it("must returns carbonPerToken equal 111111111", async () => {
+                const carbonPerToken = await instance.carbonPerToken();
 
-                expect(tokenCarbonImpact).to.equal(111111111);
+                expect(carbonPerToken).to.equal(111111111);
               });
             });
           });
@@ -1087,9 +1087,9 @@ describe("RegenerationCreditImpact", () => {
             });
 
             it("must returnstotalTreesImpact equal 213333333", async () => {
-              const tokenCarbonImpact = await instance.tokenCarbonImpact();
+              const carbonPerToken = await instance.carbonPerToken();
 
-              expect(tokenCarbonImpact).to.equal(213333333);
+              expect(carbonPerToken).to.equal(213333333);
             });
           });
         });
@@ -1144,10 +1144,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
           });
 
-          it("must returns tokenCarbonImpact equal 1133333333", async () => {
-            const tokenCarbonImpact = await instance.tokenCarbonImpact();
+          it("must returns carbonPerToken equal 1133333333", async () => {
+            const carbonPerToken = await instance.carbonPerToken();
 
-            expect(tokenCarbonImpact).to.equal(1133333333);
+            expect(carbonPerToken).to.equal(1133333333);
           });
         });
 
@@ -1183,17 +1183,17 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
           });
 
-          it("must returns tokenCarbonImpact equal 586666666", async () => {
-            const tokenCarbonImpact = await instance.tokenCarbonImpact();
+          it("must returns carbonPerToken equal 586666666", async () => {
+            const carbonPerToken = await instance.carbonPerToken();
 
-            expect(tokenCarbonImpact).to.equal(586666666);
+            expect(carbonPerToken).to.equal(586666666);
           });
         });
       });
     });
   });
 
-  describe("tokenBiodiversityImpact", () => {
+  describe("biodiversityPerToken", () => {
     beforeEach(async () => {
       await invitationRules.onlyOwnerInvite(regeneratorAddress, userTypes.Regenerator);
       await invitationRules.onlyOwnerInvite(inspectorAddress, userTypes.Inspector);
@@ -1203,10 +1203,10 @@ describe("RegenerationCreditImpact", () => {
     });
 
     context("when do not have inspections", async () => {
-      it("tokenBiodiversityImpact must be 0", async () => {
-        const tokenBiodiversityImpact = await instance.tokenBiodiversityImpact();
+      it("biodiversityPerToken must be 0", async () => {
+        const biodiversityPerToken = await instance.biodiversityPerToken();
 
-        expect(tokenBiodiversityImpact).to.equal(0);
+        expect(biodiversityPerToken).to.equal(0);
       });
     });
 
@@ -1224,10 +1224,10 @@ describe("RegenerationCreditImpact", () => {
           await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
         });
 
-        it("tokenBiodiversityImpact must be 0", async () => {
-          const tokenBiodiversityImpact = await instance.tokenBiodiversityImpact();
+        it("biodiversityPerToken must be 0", async () => {
+          const biodiversityPerToken = await instance.biodiversityPerToken();
 
-          expect(tokenBiodiversityImpact).to.equal(0);
+          expect(biodiversityPerToken).to.equal(0);
         });
       });
 
@@ -1249,10 +1249,10 @@ describe("RegenerationCreditImpact", () => {
                 await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
-              it("must returns tokenBiodiversityImpact equal 666666", async () => {
-                const tokenBiodiversityImpact = await instance.tokenBiodiversityImpact();
+              it("must returns biodiversityPerToken equal 666666", async () => {
+                const biodiversityPerToken = await instance.biodiversityPerToken();
 
-                expect(tokenBiodiversityImpact).to.equal(666666);
+                expect(biodiversityPerToken).to.equal(666666);
               });
             });
 
@@ -1266,10 +1266,10 @@ describe("RegenerationCreditImpact", () => {
                 await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
               });
 
-              it("must returns tokenBiodiversityImpact equal 1111111", async () => {
-                const tokenBiodiversityImpact = await instance.tokenBiodiversityImpact();
+              it("must returns biodiversityPerToken equal 1111111", async () => {
+                const biodiversityPerToken = await instance.biodiversityPerToken();
 
-                expect(tokenBiodiversityImpact).to.equal(1111111);
+                expect(biodiversityPerToken).to.equal(1111111);
               });
             });
           });
@@ -1281,10 +1281,10 @@ describe("RegenerationCreditImpact", () => {
               await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
             });
 
-            it("must returns tokenBiodiversityImpact equal 2133333", async () => {
-              const tokenBiodiversityImpact = await instance.tokenBiodiversityImpact();
+            it("must returns biodiversityPerToken equal 2133333", async () => {
+              const biodiversityPerToken = await instance.biodiversityPerToken();
 
-              expect(tokenBiodiversityImpact).to.equal(2133333);
+              expect(biodiversityPerToken).to.equal(2133333);
             });
           });
         });
@@ -1339,10 +1339,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
           });
 
-          it("must returns tokenBiodiversityImpact equal 11333333", async () => {
-            const tokenBiodiversityImpact = await instance.tokenBiodiversityImpact();
+          it("must returns biodiversityPerToken equal 11333333", async () => {
+            const biodiversityPerToken = await instance.biodiversityPerToken();
 
-            expect(tokenBiodiversityImpact).to.equal(11333333);
+            expect(biodiversityPerToken).to.equal(11333333);
           });
         });
 
@@ -1378,10 +1378,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
           });
 
-          it("must returns tokenBiodiversityImpact equal 5866666", async () => {
-            const tokenBiodiversityImpact = await instance.tokenBiodiversityImpact();
+          it("must returns biodiversityPerToken equal 5866666", async () => {
+            const biodiversityPerToken = await instance.biodiversityPerToken();
 
-            expect(tokenBiodiversityImpact).to.equal(5866666);
+            expect(biodiversityPerToken).to.equal(5866666);
           });
         });
 
@@ -1428,7 +1428,7 @@ describe("RegenerationCreditImpact", () => {
     });
   });
 
-  describe("tokenSoilImpact", () => {
+  describe("soilPerToken", () => {
     beforeEach(async () => {
       await invitationRules.onlyOwnerInvite(regeneratorAddress, userTypes.Regenerator);
       await invitationRules.onlyOwnerInvite(regenerator2Address, userTypes.Regenerator);
@@ -1440,10 +1440,10 @@ describe("RegenerationCreditImpact", () => {
     context("when have two regenerators", () => {
       context("when all regenerators are valids", async () => {
         context("when do not have tokens totalLocked_", () => {
-          it("tokenSoilImpact must be 1333333", async () => {
-            const tokenSoilImpact = await instance.tokenSoilImpact();
+          it("soilPerToken must be 1333333", async () => {
+            const soilPerToken = await instance.soilPerToken();
 
-            expect(tokenSoilImpact).to.equal(1333333);
+            expect(soilPerToken).to.equal(1333333);
           });
         });
 
@@ -1453,10 +1453,10 @@ describe("RegenerationCreditImpact", () => {
             await regenerationCredit.addContractPool(ZERO_ADDRESS, 300000000000000000000000000n);
           });
 
-          it("tokenSoilImpact must be 2222222", async () => {
-            const tokenSoilImpact = await instance.tokenSoilImpact();
+          it("soilPerToken must be 2222222", async () => {
+            const soilPerToken = await instance.soilPerToken();
 
-            expect(tokenSoilImpact).to.equal(2222222);
+            expect(soilPerToken).to.equal(2222222);
           });
         });
       });
@@ -1466,10 +1466,10 @@ describe("RegenerationCreditImpact", () => {
           await regeneratorRules.removePoolLevels(regenerator2Address, 0);
         });
 
-        it("tokenSoilImpact must be 666666", async () => {
-          const tokenSoilImpact = await instance.tokenSoilImpact();
+        it("soilPerToken must be 666666", async () => {
+          const soilPerToken = await instance.soilPerToken();
 
-          expect(tokenSoilImpact).to.equal(666666);
+          expect(soilPerToken).to.equal(666666);
         });
       });
     });

--- a/test/RegenerationCreditImpact.test.js
+++ b/test/RegenerationCreditImpact.test.js
@@ -505,7 +505,7 @@ describe("RegenerationCreditImpact", () => {
         });
       });
     });
-  });  
+  });
 
   describe("totalBiodiversityImpact", () => {
     beforeEach(async () => {

--- a/test/RegenerationCreditImpact.test.js
+++ b/test/RegenerationCreditImpact.test.js
@@ -22,7 +22,7 @@ describe("RegenerationCreditImpact", () => {
 
   const addRegenerator = async (name, from, _coordinates = []) => {
     const coordinatesParams = _coordinates.length > 0 ? _coordinates : coordinates();
-    await regeneratorRules.connect(from).addRegenerator(10, name, "photoURL", coordinatesParams);
+    await regeneratorRules.connect(from).addRegenerator(1000, name, "photoURL", coordinatesParams);
   };
 
   const addInspector = async (name, from) => {
@@ -734,10 +734,10 @@ describe("RegenerationCreditImpact", () => {
 
     context("when have two regenerators", () => {
       context("when all regenerators are valids", async () => {
-        it("totalSoilImpact must be 20", async () => {
+        it("totalSoilImpact must be 2000", async () => {
           const totalSoilImpact = await instance.totalSoilImpact();
 
-          expect(totalSoilImpact).to.equal(20);
+          expect(totalSoilImpact).to.equal(2000);
         });
       });
 
@@ -746,10 +746,10 @@ describe("RegenerationCreditImpact", () => {
           await regeneratorRules.removePoolLevels(regenerator2Address, 0);
         });
 
-        it("totalSoilImpact must be 10", async () => {
+        it("totalSoilImpact must be 1000", async () => {
           const totalSoilImpact = await instance.totalSoilImpact();
 
-          expect(totalSoilImpact).to.equal(10);
+          expect(totalSoilImpact).to.equal(1000);
         });
       });
     });
@@ -1440,10 +1440,10 @@ describe("RegenerationCreditImpact", () => {
     context("when have two regenerators", () => {
       context("when all regenerators are valids", async () => {
         context("when do not have tokens totalLocked_", () => {
-          it("soilPerToken must be 1333333", async () => {
+          it("soilPerToken must be 133333333", async () => {
             const soilPerToken = await instance.soilPerToken();
 
-            expect(soilPerToken).to.equal(1333333);
+            expect(soilPerToken).to.equal(133333333);
           });
         });
 
@@ -1453,10 +1453,10 @@ describe("RegenerationCreditImpact", () => {
             await regenerationCredit.addContractPool(ZERO_ADDRESS, 300000000000000000000000000n);
           });
 
-          it("soilPerToken must be 2222222", async () => {
+          it("soilPerToken must be 222222222", async () => {
             const soilPerToken = await instance.soilPerToken();
 
-            expect(soilPerToken).to.equal(2222222);
+            expect(soilPerToken).to.equal(222222222);
           });
         });
       });
@@ -1466,10 +1466,10 @@ describe("RegenerationCreditImpact", () => {
           await regeneratorRules.removePoolLevels(regenerator2Address, 0);
         });
 
-        it("soilPerToken must be 666666", async () => {
+        it("soilPerToken must be 66666666", async () => {
           const soilPerToken = await instance.soilPerToken();
 
-          expect(soilPerToken).to.equal(666666);
+          expect(soilPerToken).to.equal(66666666);
         });
       });
     });

--- a/test/RegenerationCreditImpact.test.js
+++ b/test/RegenerationCreditImpact.test.js
@@ -177,7 +177,7 @@ describe("RegenerationCreditImpact", () => {
             });
           });
 
-          context("when inspection biomass impact is 25", () => {
+          context("when inspection trees impact is 25", () => {
             beforeEach(async () => {
               treesIndicatorValue = 32;
 
@@ -330,6 +330,182 @@ describe("RegenerationCreditImpact", () => {
       });
     });
   });
+
+  describe("totalCarbonImpact", () => {
+    beforeEach(async () => {
+      await invitationRules.onlyOwnerInvite(regeneratorAddress, userTypes.Regenerator);
+      await invitationRules.onlyOwnerInvite(inspectorAddress, userTypes.Inspector);
+
+      await addRegenerator("Regenerator A", regeneratorAddress);
+      await addInspector("Inspector A", inspectorAddress);
+    });
+
+    context("when do not have inspections", async () => {
+      it("totalCarbonImpact must be 0", async () => {
+        const totalCarbonImpact = await instance.totalCarbonImpact();
+
+        expect(totalCarbonImpact).to.equal(0);
+      });
+    });
+
+    context("when have inspections", () => {
+      context("when inspectionsTreesImpact is 0", () => {
+        beforeEach(async () => {
+          await inspectionRules.connect(regeneratorAddress).requestInspection();
+
+          await advanceBlock(5);
+
+          await inspectionRules.connect(inspectorAddress).acceptInspection(1);
+
+          treesIndicatorValue = 0;
+
+          await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+        });
+
+        it("totalCarbonImpact must be 0", async () => {
+          const totalCarbonImpact = await instance.totalCarbonImpact();
+
+          expect(totalCarbonImpact).to.equal(0);
+        });
+      });
+
+      context("when inspectionsTreesImpact is not 0", () => {
+        beforeEach(async () => {
+          await inspectionRules.connect(regeneratorAddress).requestInspection();
+
+          await advanceBlock(5);
+
+          await inspectionRules.connect(inspectorAddress).acceptInspection(1);
+        });
+
+        context("when have 1 inspection", () => {
+          context("when inspection trees impact is 10", () => {
+            beforeEach(async () => {
+              treesIndicatorValue = 10;
+
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+            });
+
+            it("must returnstotalCarbonImpact equal 1000", async () => {
+              const totalCarbonImpact = await instance.totalCarbonImpact();
+
+              expect(totalCarbonImpact).to.equal(1000);
+            });
+          });
+
+          context("when inspection trees impact is 25", () => {
+            beforeEach(async () => {
+              treesIndicatorValue = 32;
+
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+            });
+
+            it("must returnstotalCarbonImpact equal 3200", async () => {
+              const totalCarbonImpact = await instance.totalCarbonImpact();
+
+              expect(totalCarbonImpact).to.equal(3200);
+            });
+          });
+        });
+
+        context("when have 5 inspections valid", () => {
+          beforeEach(async () => {
+            await invitationRules.onlyOwnerInvite(regenerator2Address, userTypes.Regenerator);
+            await invitationRules.onlyOwnerInvite(regenerator3Address, userTypes.Regenerator);
+            await invitationRules.onlyOwnerInvite(regenerator4Address, userTypes.Regenerator);
+            await invitationRules.onlyOwnerInvite(regenerator5Address, userTypes.Regenerator);
+
+            await invitationRules.onlyOwnerInvite(inspector2Address, userTypes.Inspector);
+            await invitationRules.onlyOwnerInvite(inspector3Address, userTypes.Inspector);
+            await invitationRules.onlyOwnerInvite(inspector4Address, userTypes.Inspector);
+            await invitationRules.onlyOwnerInvite(inspector5Address, userTypes.Inspector);
+
+            await addRegenerator("Regenerator B", regenerator2Address);
+            await addRegenerator("Regenerator C", regenerator3Address);
+            await addRegenerator("Regenerator D", regenerator4Address);
+            await addRegenerator("Regenerator E", regenerator5Address);
+
+            await addInspector("Inspector B", inspector2Address);
+            await addInspector("Inspector C", inspector3Address);
+            await addInspector("Inspector D", inspector4Address);
+            await addInspector("Inspector E", inspector5Address);
+
+            await inspectionRules.connect(regenerator2Address).requestInspection();
+            await inspectionRules.connect(regenerator3Address).requestInspection();
+            await inspectionRules.connect(regenerator4Address).requestInspection();
+            await inspectionRules.connect(regenerator5Address).requestInspection();
+
+            await advanceBlock(5);
+
+            await inspectionRules.connect(inspector2Address).acceptInspection(2);
+            await inspectionRules.connect(inspector3Address).acceptInspection(3);
+            await inspectionRules.connect(inspector4Address).acceptInspection(4);
+            await inspectionRules.connect(inspector5Address).acceptInspection(5);
+
+            treesIndicatorValue = 32;
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+
+            treesIndicatorValue = 0;
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
+
+            treesIndicatorValue = 100;
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
+
+            treesIndicatorValue = 10;
+            await realizeInspection(4, "report", treesResultValue(), biodiversityResultValue(), inspector4Address);
+
+            treesIndicatorValue = 32;
+            await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
+          });
+
+          it("must returnstotalCarbonImpact equal 17000", async () => {
+            const totalCarbonImpact = await instance.totalCarbonImpact();
+
+            expect(totalCarbonImpact).to.equal(17000);
+          });
+        });
+
+        context("when have 3 inspections valids and two are of same regenerator", () => {
+          beforeEach(async () => {
+            await invitationRules.onlyOwnerInvite(regenerator2Address, userTypes.Regenerator);
+            await invitationRules.onlyOwnerInvite(regenerator3Address, userTypes.Regenerator);
+
+            await invitationRules.onlyOwnerInvite(inspector2Address, userTypes.Inspector);
+            await invitationRules.onlyOwnerInvite(inspector3Address, userTypes.Inspector);
+
+            await addRegenerator("Regenerator B", regenerator2Address);
+            await addRegenerator("Regenerator C", regenerator3Address);
+
+            await addInspector("Inspector B", inspector2Address);
+            await addInspector("Inspector C", inspector3Address);
+
+            treesIndicatorValue = 32;
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+
+            await inspectionRules.connect(regeneratorAddress).requestInspection();
+            await inspectionRules.connect(regenerator2Address).requestInspection();
+
+            await advanceBlock(5);
+
+            await inspectionRules.connect(inspector2Address).acceptInspection(2);
+            await inspectionRules.connect(inspector3Address).acceptInspection(3);
+
+            treesIndicatorValue = 0;
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
+
+            treesIndicatorValue = 100;
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
+          });
+
+          it("must returnstotalCarbonImpact equal 8800", async () => {
+            const totalCarbonImpact = await instance.totalCarbonImpact();
+
+            expect(totalCarbonImpact).to.equal(8800);
+          });
+        });
+      });
+    });
+  });  
 
   describe("totalBiodiversityImpact", () => {
     beforeEach(async () => {
@@ -627,7 +803,7 @@ describe("RegenerationCreditImpact", () => {
         });
 
         context("when have 1 inspection", () => {
-          context("when inspection biomass impact is 10", () => {
+          context("when inspection trees impact is 10", () => {
             beforeEach(async () => {
               treesIndicatorValue = 10;
             });
@@ -664,7 +840,7 @@ describe("RegenerationCreditImpact", () => {
             });
           });
 
-          context("when inspection biomass impact is 25", () => {
+          context("when inspection trees impact is 25", () => {
             beforeEach(async () => {
               treesIndicatorValue = 32;
 
@@ -814,6 +990,205 @@ describe("RegenerationCreditImpact", () => {
         //     expect(totalTreesImpact).to.equal(44);
         //   });
         // });
+      });
+    });
+  });
+
+  describe("tokenCarbonImpact", () => {
+    beforeEach(async () => {
+      await invitationRules.onlyOwnerInvite(regeneratorAddress, userTypes.Regenerator);
+      await invitationRules.onlyOwnerInvite(inspectorAddress, userTypes.Inspector);
+
+      await addRegenerator("Regenerator A", regeneratorAddress);
+      await addInspector("Inspector A", inspectorAddress);
+    });
+
+    context("when do not have inspections", async () => {
+      it("tokenCarbonImpact must be 0", async () => {
+        const tokenCarbonImpact = await instance.tokenCarbonImpact();
+
+        expect(tokenCarbonImpact).to.equal(0);
+      });
+    });
+
+    context("when have inspections", () => {
+      context("when inspectionsTreesImpact is 0", () => {
+        beforeEach(async () => {
+          await inspectionRules.connect(regeneratorAddress).requestInspection();
+
+          await advanceBlock(5);
+
+          await inspectionRules.connect(inspectorAddress).acceptInspection(1);
+
+          treesIndicatorValue = 0;
+
+          await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+        });
+
+        it("tokenCarbonImpact must be 0", async () => {
+          const tokenCarbonImpact = await instance.tokenCarbonImpact();
+
+          expect(tokenCarbonImpact).to.equal(0);
+        });
+      });
+
+      context("when inspectionsTreesImpact is not 0", () => {
+        beforeEach(async () => {
+          await inspectionRules.connect(regeneratorAddress).requestInspection();
+
+          await advanceBlock(5);
+
+          await inspectionRules.connect(inspectorAddress).acceptInspection(1);
+        });
+
+        context("when have 1 inspection", () => {
+          context("when inspection trees impact is 10", () => {
+            beforeEach(async () => {
+              treesIndicatorValue = 10;
+            });
+
+            context("when do not have tokens totalLocked_", () => {
+              beforeEach(async () => {
+                treesIndicatorValue = 10;
+
+                await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+              });
+
+              it("must returns tokenCarbonImpact equal 66666666", async () => {
+                const tokenCarbonImpact = await instance.tokenCarbonImpact();
+
+                expect(tokenCarbonImpact).to.equal(66666666);
+              });
+            });
+
+            context("when have token totalLocked_", () => {
+              beforeEach(async () => {
+                await regenerationCredit.addContractPool(ZERO_ADDRESS, 300000000000000000000000000n);
+                await regenerationCredit.addContractPool(ZERO_ADDRESS, 300000000000000000000000000n);
+
+                treesIndicatorValue = 10;
+
+                await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+              });
+
+              it("must returns tokenCarbonImpact equal 111111111", async () => {
+                const tokenCarbonImpact = await instance.tokenCarbonImpact();
+
+                expect(tokenCarbonImpact).to.equal(111111111);
+              });
+            });
+          });
+
+          context("when inspection trees impact is 25", () => {
+            beforeEach(async () => {
+              treesIndicatorValue = 32;
+
+              await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+            });
+
+            it("must returnstotalTreesImpact equal 213333333", async () => {
+              const tokenCarbonImpact = await instance.tokenCarbonImpact();
+
+              expect(tokenCarbonImpact).to.equal(213333333);
+            });
+          });
+        });
+
+        context("when have 5 inspections valid", () => {
+          beforeEach(async () => {
+            await invitationRules.onlyOwnerInvite(regenerator2Address, userTypes.Regenerator);
+            await invitationRules.onlyOwnerInvite(regenerator3Address, userTypes.Regenerator);
+            await invitationRules.onlyOwnerInvite(regenerator4Address, userTypes.Regenerator);
+            await invitationRules.onlyOwnerInvite(regenerator5Address, userTypes.Regenerator);
+
+            await invitationRules.onlyOwnerInvite(inspector2Address, userTypes.Inspector);
+            await invitationRules.onlyOwnerInvite(inspector3Address, userTypes.Inspector);
+            await invitationRules.onlyOwnerInvite(inspector4Address, userTypes.Inspector);
+            await invitationRules.onlyOwnerInvite(inspector5Address, userTypes.Inspector);
+
+            await addRegenerator("Regenerator B", regenerator2Address);
+            await addRegenerator("Regenerator C", regenerator3Address);
+            await addRegenerator("Regenerator D", regenerator4Address);
+            await addRegenerator("Regenerator E", regenerator5Address);
+
+            await addInspector("Inspector B", inspector2Address);
+            await addInspector("Inspector C", inspector3Address);
+            await addInspector("Inspector D", inspector4Address);
+            await addInspector("Inspector E", inspector5Address);
+
+            await inspectionRules.connect(regenerator2Address).requestInspection();
+            await inspectionRules.connect(regenerator3Address).requestInspection();
+            await inspectionRules.connect(regenerator4Address).requestInspection();
+            await inspectionRules.connect(regenerator5Address).requestInspection();
+
+            await advanceBlock(5);
+
+            await inspectionRules.connect(inspector2Address).acceptInspection(2);
+            await inspectionRules.connect(inspector3Address).acceptInspection(3);
+            await inspectionRules.connect(inspector4Address).acceptInspection(4);
+            await inspectionRules.connect(inspector5Address).acceptInspection(5);
+
+            treesIndicatorValue = 32;
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+
+            treesIndicatorValue = 0;
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
+
+            treesIndicatorValue = 100;
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
+
+            treesIndicatorValue = 10;
+            await realizeInspection(4, "report", treesResultValue(), biodiversityResultValue(), inspector4Address);
+
+            treesIndicatorValue = 32;
+            await realizeInspection(5, "report", treesResultValue(), biodiversityResultValue(), inspector5Address);
+          });
+
+          it("must returns tokenCarbonImpact equal 1133333333", async () => {
+            const tokenCarbonImpact = await instance.tokenCarbonImpact();
+
+            expect(tokenCarbonImpact).to.equal(1133333333);
+          });
+        });
+
+        context("when have 3 inspections valids and two are of same regenerator", () => {
+          beforeEach(async () => {
+            await invitationRules.onlyOwnerInvite(regenerator2Address, userTypes.Regenerator);
+            await invitationRules.onlyOwnerInvite(regenerator3Address, userTypes.Regenerator);
+
+            await invitationRules.onlyOwnerInvite(inspector2Address, userTypes.Inspector);
+            await invitationRules.onlyOwnerInvite(inspector3Address, userTypes.Inspector);
+
+            await addRegenerator("Regenerator B", regenerator2Address);
+            await addRegenerator("Regenerator C", regenerator3Address);
+
+            await addInspector("Inspector B", inspector2Address);
+            await addInspector("Inspector C", inspector3Address);
+
+            treesIndicatorValue = 32;
+            await realizeInspection(1, "report", treesResultValue(), biodiversityResultValue(), inspectorAddress);
+
+            await inspectionRules.connect(regeneratorAddress).requestInspection();
+            await inspectionRules.connect(regenerator2Address).requestInspection();
+
+            await advanceBlock(5);
+
+            await inspectionRules.connect(inspector2Address).acceptInspection(2);
+            await inspectionRules.connect(inspector3Address).acceptInspection(3);
+
+            treesIndicatorValue = 0;
+            await realizeInspection(2, "report", treesResultValue(), biodiversityResultValue(), inspector2Address);
+
+            treesIndicatorValue = 100;
+            await realizeInspection(3, "report", treesResultValue(), biodiversityResultValue(), inspector3Address);
+          });
+
+          it("must returns tokenCarbonImpact equal 586666666", async () => {
+            const tokenCarbonImpact = await instance.tokenCarbonImpact();
+
+            expect(tokenCarbonImpact).to.equal(586666666);
+          });
+        });
       });
     });
   });

--- a/test/RegenerationIndexRules.test.js
+++ b/test/RegenerationIndexRules.test.js
@@ -50,7 +50,7 @@ describe("RegenerationIndexRules", () => {
       categoryRegenerationIndexDescriptions = categoryRegenerationIndexDescriptions.toString();
 
       expect(categoryRegenerationIndexDescriptions).to.equal(
-        "1,Trees > 10000,2,10000 > Trees > 4000,3,4000 > Trees > 2000,4,2000 > Trees > 500,5,500 > Trees > 100,6,100 > Trees > 10,7,Trees < 10"
+        "1,Trees > 20000,2,20000 > Trees > 10000,3,10000 > Trees > 5000,4,5000 > Trees > 1000,5,1000 > Trees > 100,6,100 > Trees > 10,7,Trees < 10"
       );
     });
 

--- a/test/RegenerationIndexRules.test.js
+++ b/test/RegenerationIndexRules.test.js
@@ -4,7 +4,7 @@ describe("RegenerationIndexRules", () => {
   let instance;
   let owner;
 
-  const biomassResultValue = {
+  const treesResultValue = {
     categoryId: 1,
     indicator: 100001,
   };
@@ -26,9 +26,9 @@ describe("RegenerationIndexRules", () => {
       const category = await instance.categories(1);
 
       expect(category.id).to.equal(1);
-      expect(category.name).to.equal("Biomass");
+      expect(category.name).to.equal("Trees");
       expect(category.description).to.equal(
-        "Indicator to measure the total amount of biomass in the regenerating area. How much organic matter is there on the site? Estimate by including living biomass, such as trees, plants and roots, as well as dead biomass, which includes leaves, branches, wood and other types of organic matter covering the soil. The result should be expressed in tons [t]"
+        "Indicator to measure the total amount of trees, palm trees and other plants over 5cm in diameter in the regenerating area. How many trees, palm trees and other plants with more than 5cm of diameters there is in the regenerating area? Justify your answer in the report."
       );
     });
 
@@ -38,7 +38,7 @@ describe("RegenerationIndexRules", () => {
       expect(category.id).to.equal(2);
       expect(category.name).to.equal("Biodiversity");
       expect(category.description).to.equal(
-        "Indicator to measure the level of plant biodiversity in the regenerating area. How many different species are there in the area? Each different species is equivalent to one point and only trees and plants managed or planted by the regenerator should be counted"
+        "Indicator to measure the level of biodiversity of trees, palm trees and other plants over 5cm of diamater in the regenerating area. How many different species are there in the area? Each different species is equivalent to one point and only trees and plants managed or planted by the regenerator should be counted."
       );
     });
   });
@@ -73,7 +73,7 @@ describe("RegenerationIndexRules", () => {
 
       context("when category and regeneration index exists", () => {
         it("calculate regenerationScore", async () => {
-          const score = await instance.calculateScore(biomassResultValue, biodiversityResultValue);
+          const score = await instance.calculateScore(treesResultValue, biodiversityResultValue);
 
           expect(score).to.equal(64);
         });

--- a/test/RegenerationIndexRules.test.js
+++ b/test/RegenerationIndexRules.test.js
@@ -50,7 +50,7 @@ describe("RegenerationIndexRules", () => {
       categoryRegenerationIndexDescriptions = categoryRegenerationIndexDescriptions.toString();
 
       expect(categoryRegenerationIndexDescriptions).to.equal(
-        "1,Balance > 100.000,2,100.000 > Balance > 10.000,3,10.000 > Balance > 1000,4,1000 > Balance > 100,5,100 > Balance > 10,6,10 > Balance > 0,7,Not applicable"
+        "1,Trees > 10000,2,10000 > Trees > 4000,3,4000 > Trees > 2000,4,2000 > Trees > 500,5,500 > Trees > 100,6,100 > Trees > 10,7,Trees < 10"
       );
     });
 
@@ -60,7 +60,7 @@ describe("RegenerationIndexRules", () => {
       categoryRegenerationIndexDescriptions = categoryRegenerationIndexDescriptions.toString();
 
       expect(categoryRegenerationIndexDescriptions).to.equal(
-        "1,Biodiversity > 1000,2,1000 > Biodiversity > 500,3,500 > Biodiversity > 200,4,200 > Biodiversity > 100,5,100 > Biodiversity > 50,6,50 > Biodiversity > 25,7,Biodiversity < 25"
+        "1,Biodiversity > 240,2,240 > Biodiversity > 120,3,120 > Biodiversity > 60,4,60 > Biodiversity > 30,5,30 > Biodiversity > 15,6,15 > Biodiversity > 5,7,Biodiversity < 5"
       );
     });
   });

--- a/test/RegeneratorRules.test.js
+++ b/test/RegeneratorRules.test.js
@@ -13,6 +13,11 @@ describe("RegeneratorRules", () => {
 
   const addRegenerator = async (name, from, _coordinates = []) => {
     const test = _coordinates.length > 0 ? _coordinates : coordinates();
+    await instance.connect(from).addRegenerator(1000, name, "photoURL", test);
+  };
+
+  const addRegenerator2 = async (name, from, _coordinates = []) => {
+    const test = _coordinates.length > 0 ? _coordinates : coordinates();
     await instance.connect(from).addRegenerator(10, name, "photoURL", test);
   };
 
@@ -85,7 +90,7 @@ describe("RegeneratorRules", () => {
       expect(regenerator.regeneratorWallet).to.equal(prod1Address.address);
       expect(regenerator.name).to.equal("Regenerator A");
       expect(regenerator.proofPhoto).to.equal("photoURL");
-      expect(regenerator.totalArea).to.equal("10");
+      expect(regenerator.totalArea).to.equal("1000");
       expect(regenerator.totalInspections).to.equal(0);
       expect(regenerator.pendingInspection).to.equal(false);
       expect(regenerator.regenerationScore.average).to.equal("0");
@@ -164,7 +169,7 @@ describe("RegeneratorRules", () => {
       await addRegenerator("Regenerator B", prod2Address);
 
       const newRegenerationArea = await instance.regenerationArea();
-      expect(newRegenerationArea).to.equal(20);
+      expect(newRegenerationArea).to.equal(2000);
     });
   });
 
@@ -235,6 +240,12 @@ describe("RegeneratorRules", () => {
           "Minimum 3 and maximum 10 coordinate points"
         );
       });
+    });
+  });
+
+  context("when totalArea is below 1000", () => {
+    it("should return error", async () => {
+      await expect(addRegenerator2("Regenerator A", prod1Address)).to.be.revertedWith("Minimum 1000 square meters");
     });
   });
 
@@ -331,7 +342,7 @@ describe("RegeneratorRules", () => {
             });
           });
 
-          context("when have more tha one regenerator", () => {
+          context("when have more than one regenerator", () => {
             beforeEach(async () => {
               await instance.afterRealizeInspection(prod1Address, 600);
               await addRegenerator("Regenerator B", prod2Address);

--- a/test/RegeneratorRules.test.js
+++ b/test/RegeneratorRules.test.js
@@ -245,7 +245,7 @@ describe("RegeneratorRules", () => {
 
   context("when totalArea is below 1000", () => {
     it("should return error", async () => {
-      await expect(addRegenerator2("Regenerator A", prod1Address)).to.be.revertedWith("Minimum 1000 square meters");
+      await expect(addRegenerator2("Regenerator A", prod1Address)).to.be.revertedWith("Minimum 500 square meters");
     });
   });
 

--- a/test/ValidatorRules.test.js
+++ b/test/ValidatorRules.test.js
@@ -117,7 +117,7 @@ describe("ValidatorRules", () => {
   };
 
   const addRegenerator = async (name, from) => {
-    await regeneratorRules.connect(from).addRegenerator(10, name, "photoURL", coordinates());
+    await regeneratorRules.connect(from).addRegenerator(1000, name, "photoURL", coordinates());
   };
 
   const coordinates = () => {
@@ -521,7 +521,7 @@ describe("ValidatorRules", () => {
               it("regenerationArea should be decremented", async () => {
                 const decrementedArea = await regeneratorRules.regenerationArea();
 
-                expect(decrementedArea).to.equal(10);
+                expect(decrementedArea).to.equal(1000);
               });
 
               it("must emit DeniedUserEevent", async () => {


### PR DESCRIPTION
New logic  that changes the result of the inspections from biomass to trees. The objective of this change is to make it simpler to inspectors realize inspections and the methodologies.

We introduced a constant that estimates the amount of carbon that each tree/plant sequesters during it lifetime.

So now we have the totalTrees of the system, and also the totalCarbon. And the treesPerToken and carbonPerToken as well.