### PR TITLE
supporter profilePhoto

### DIFF
--- a/contracts/SupporterRules.sol
+++ b/contracts/SupporterRules.sol
@@ -64,16 +64,22 @@ contract SupporterRules {
    * @param name The name of the supporter
    * @return a supporter
    */
-  function addSupporter(string memory name) public returns (Supporter memory) {
+  function addSupporter(string memory name, string memory profilePhoto) public returns (Supporter memory) {
     uint256 id = communityRules.userTypesTotalCount(USER_TYPE) + 1;
 
-    Supporter memory supporter = Supporter(id, msg.sender, name, block.number);
+    Supporter memory supporter = Supporter(id, msg.sender, name, profilePhoto, block.number);
 
     supporters[msg.sender] = supporter;
     supportersAddress[id] = msg.sender;
     communityRules.addUser(msg.sender, USER_TYPE);
 
     return supporter;
+  }
+
+  function updateProfilePhoto(string memory newPhoto) public {
+    require(communityRules.userTypeIs(UserType.SUPPORTER, msg.sender), "Only supporters");
+
+    supporters[msg.sender].profilePhoto = newPhoto;
   }
 
   /**

--- a/contracts/types/SupporterTypes.sol
+++ b/contracts/types/SupporterTypes.sol
@@ -14,6 +14,7 @@ struct Supporter {
   uint256 id;
   address supporterWallet;
   string name;
+  string profilePhoto;
   uint256 createdAt;
 }
 

--- a/test/SupporterRules.test.js
+++ b/test/SupporterRules.test.js
@@ -9,8 +9,12 @@ describe("SupporterRules", () => {
   let instance, communityRules, regenerationCredit, supporterPool, researcherRules;
   let ownerAddress, inv1Address, inv2Address, user1Address;
 
-  const addSupporter = async (name, from) => {
-    await instance.connect(from).addSupporter(name);
+  const addSupporter = async (name, profilePhoto, from) => {
+    await instance.connect(from).addSupporter(name, profilePhoto);
+  };
+
+  const updateProfilePhoto = async (newPhoto, from) => {
+    await instance.connect(from).updateProfilePhoto(newPhoto);
   };
 
   const transferTokensTo = async (userAddress, tokens) => {
@@ -71,30 +75,33 @@ describe("SupporterRules", () => {
   describe("#addSupporter", () => {
     context("when supporter exists", () => {
       it("should return error", async () => {
-        await addSupporter("Supporter A", inv1Address);
-        await expect(addSupporter("Supporter A", inv1Address)).to.be.revertedWith("User already exists");
+        await addSupporter("Supporter A", "profilePhoto", inv1Address);
+        await expect(addSupporter("Supporter A", "profilePhoto", inv1Address)).to.be.revertedWith(
+          "User already exists"
+        );
       });
     });
 
     context("when supporter don't exist", () => {
       it("create supporter", async () => {
-        await addSupporter("Supporter A", inv1Address);
-        await addSupporter("Supporter B", inv2Address);
+        await addSupporter("Supporter A", "profilePhoto", inv1Address);
+        await addSupporter("Supporter B", "profilePhoto", inv2Address);
         const supporter = await instance.getSupporter(inv1Address);
 
         expect(supporter.supporterWallet).to.equal(inv1Address.address);
+        expect(supporter.profilePhoto).to.equal("profilePhoto");
       });
 
       it("increment supporterCount", async () => {
-        await addSupporter("Supporter A", inv1Address);
-        await addSupporter("Supporter B", inv2Address);
+        await addSupporter("Supporter A", "profilePhoto", inv1Address);
+        await addSupporter("Supporter B", "profilePhoto", inv2Address);
         const supportersCount = await communityRules.userTypesCount(userTypes.Supporter);
 
         expect(supportersCount).to.equal(2);
       });
 
       it("add created supporter in userType contract as a SUPPORTER", async () => {
-        await addSupporter("Supporter A", inv1Address);
+        await addSupporter("Supporter A", "profilePhoto", inv1Address);
 
         const userType = await communityRules.getUser(inv1Address);
         const SUPPORTER = 7;
@@ -104,20 +111,41 @@ describe("SupporterRules", () => {
     });
   });
 
+  describe("#updateProfilePhoto", () => {
+    context("without supporter", () => {
+      it("should return error", async () => {
+        await addSupporter("Supporter A", "profilePhoto", inv1Address);
+        await expect(updateProfilePhoto("newPhoto", inv2Address)).to.be.revertedWith("Only supporters");
+      });
+    });
+
+    context("with supporter", () => {
+      it("should update photo", async () => {
+        await addSupporter("Supporter A", "profilePhoto", inv1Address);
+        await updateProfilePhoto("newPhoto", inv1Address);
+        const supporter = await instance.getSupporter(inv1Address);
+
+        expect(supporter.supporterWallet).to.equal(inv1Address.address);
+        expect(supporter.profilePhoto).to.equal("newPhoto");
+      });
+    });
+  });
+
   describe("#getSupporter", () => {
     it("return a supporter", async () => {
-      await addSupporter("Supporter A", inv1Address);
+      await addSupporter("Supporter A", "profilePhoto", inv1Address);
 
       const supporter = await instance.getSupporter(inv1Address);
 
       expect(supporter.supporterWallet).to.equal(inv1Address.address);
+      expect(supporter.profilePhoto).to.equal("profilePhoto");
     });
   });
 
   describe("#burnTokensCalculator", () => {
     context("when msg.sender is SUPPORTER", () => {
       beforeEach(async () => {
-        await addSupporter("Supporter A", inv1Address);
+        await addSupporter("Supporter A", "profilePhoto", inv1Address);
       });
 
       context("when amount is greater than zero", () => {
@@ -132,7 +160,7 @@ describe("SupporterRules", () => {
           context("when SUPPORTER was invited", () => {
             beforeEach(async () => {
               await communityRules.addInvitation(inv1Address, inv2Address, userTypes.Supporter);
-              await addSupporter("Supporter B", inv2Address);
+              await addSupporter("Supporter B", "profilePhoto", inv2Address);
               await transferTokensTo(inv2Address, 100000000000000000000n);
             });
 
@@ -243,7 +271,7 @@ describe("SupporterRules", () => {
         context("when calculatorItemId does not exists", () => {
           beforeEach(async () => {
             await communityRules.addInvitation(inv1Address, inv2Address, userTypes.Supporter);
-            await addSupporter("Supporter B", inv2Address);
+            await addSupporter("Supporter B", "profilePhoto", inv2Address);
             await transferTokensTo(inv2Address, 100000000000000000000n);
             await instance.connect(inv2Address).burnTokensCalculator(1000000000000000000n, 10);
           });
@@ -275,7 +303,7 @@ describe("SupporterRules", () => {
   describe("#burnTokensPublication", () => {
     context("when msg.sender is SUPPORTER", () => {
       beforeEach(async () => {
-        await addSupporter("Supporter A", inv1Address);
+        await addSupporter("Supporter A", "profilePhoto", inv1Address);
       });
 
       context("when amount is greater than zero", () => {
@@ -283,7 +311,7 @@ describe("SupporterRules", () => {
           context("when SUPPORTER was invited", () => {
             beforeEach(async () => {
               await communityRules.addInvitation(inv1Address, inv2Address, userTypes.Supporter);
-              await addSupporter("Supporter B", inv2Address);
+              await addSupporter("Supporter B", "profilePhoto", inv2Address);
               await transferTokensTo(inv2Address, 100000000000000000000n);
             });
 
@@ -416,7 +444,7 @@ describe("SupporterRules", () => {
 
   describe("#declareReductionCommitment", () => {
     beforeEach(async () => {
-      await addSupporter("Supporter A", inv1Address);
+      await addSupporter("Supporter A", "profilePhoto", inv1Address);
     });
 
     context("when is supporter", () => {


### PR DESCRIPTION
New supporters profilePhoto. A string to allow supporter to upload a profile photo and store that hash of the file. Also, and updateProfilePhoto function to allow them to update it whenever they want. 