### PR TITLE
refact offset

### DIFF
--- a/contracts/SupporterRules.sol
+++ b/contracts/SupporterRules.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.7.0 <=0.9.0;
 import { CommunityRules } from "./CommunityRules.sol";
 import { ResearcherRules } from "./ResearcherRules.sol";
 import { CalculatorItem } from "./types/ResearcherTypes.sol";
-import { Supporter, Publication, PublicationId } from "./types/SupporterTypes.sol";
+import { Supporter, Publication, PublicationId, Offset, OffsetId } from "./types/SupporterTypes.sol";
 import { UserType, Invitation } from "./types/CommunityTypes.sol";
 import { SupporterPool } from "./SupporterPool.sol";
 import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
@@ -37,6 +37,12 @@ contract SupporterRules {
   mapping(address => PublicationId[]) public publicationIds;
 
   uint256 public publicationsCount;
+
+  mapping(uint256 => Offset) public offsets;
+
+  mapping(address => OffsetId[]) public offsetIds;
+
+  uint256 public offsetsCount;
 
   /// @notice Commission percentage on invited burn
   uint256 public constant INVITER_PERCENTAGE = 5;
@@ -81,16 +87,23 @@ contract SupporterRules {
    * @param amount Tokens burned
    * @param calculatorItemId Calculator item id
    */
-  function burnTokensCalculator(uint256 amount, uint256 calculatorItemId) public {
+  function offset(uint256 amount, uint256 calculatorItemId) public {
     require(communityRules.userTypeIs(UserType.SUPPORTER, msg.sender), "Only supporters");
     require(amount > 0, "Amount invalid");
 
     uint256 amountBurn = burnTokens(amount);
 
+    uint256 id = offsetsCount + 1;
+
     if (calculatorItemId > 0) {
       CalculatorItem memory calculatorItem = researcherRules.getCalculatorItem(calculatorItemId);
       if (calculatorItem.id > 0) calculatorItemCertificates[msg.sender][calculatorItemId] = amountBurn;
     }
+
+    offsets[id] = Offset(msg.sender, block.number, amountBurn, calculatorItemId);
+
+    offsetIds[msg.sender].push(OffsetId(id));
+    offsetsCount++;
   }
 
   /**
@@ -99,7 +112,7 @@ contract SupporterRules {
    * @param description Post description
    * @param content Post content
    */
-  function burnTokensPublication(uint256 amount, string memory description, string memory content) public {
+  function publish(uint256 amount, string memory description, string memory content) public {
     require(communityRules.userTypeIs(UserType.SUPPORTER, msg.sender), "Only supporters");
     require(amount > 1, "Amount invalid");
 

--- a/contracts/types/SupporterTypes.sol
+++ b/contracts/types/SupporterTypes.sol
@@ -33,9 +33,23 @@ struct Publication {
   string content;
 }
 
+struct Offset {
+  address supporterAddress;
+  uint256 createdAt;
+  uint256 amountBurn;
+  uint256 calculatorItemId;
+}
+
 /**
  * @dev PublicationId data structure
  */
 struct PublicationId {
+  uint256 id;
+}
+
+/**
+ * @dev OffsetId data structure
+ */
+struct OffsetId {
   uint256 id;
 }

--- a/test/SupporterRules.test.js
+++ b/test/SupporterRules.test.js
@@ -114,7 +114,7 @@ describe("SupporterRules", () => {
     });
   });
 
-  describe("#burnTokensCalculator", () => {
+  describe("#offset", () => {
     context("when msg.sender is SUPPORTER", () => {
       beforeEach(async () => {
         await addSupporter("Supporter A", inv1Address);
@@ -138,7 +138,7 @@ describe("SupporterRules", () => {
 
             context("when burn 1000000000000000000 tokens", () => {
               beforeEach(async () => {
-                await instance.connect(inv2Address).burnTokensCalculator(1000000000000000000n, 1);
+                await instance.connect(inv2Address).offset(1000000000000000000n, 1);
               });
 
               it("Supporter balance must be 99000000000000000000", async () => {
@@ -161,11 +161,23 @@ describe("SupporterRules", () => {
 
                 expect(value).to.equal(950000000000000000n);
               });
+
+              it("must add offset amount", async () => {
+                const offset = await instance.offsets(1);
+                expect(offset.supporterAddress).to.equal(inv2Address);
+                expect(offset.amountBurn).to.equal("950000000000000000");
+                expect(offset.calculatorItemId).to.equal(1);
+              });
+
+              it("must add offset count", async () => {
+                const offsetsCount = await instance.offsetsCount();
+                expect(offsetsCount).to.equal(1);
+              });
             });
 
             context("when burn 500000000000000000 tokens", () => {
               beforeEach(async () => {
-                await instance.connect(inv2Address).burnTokensCalculator(500000000000000000n, 1);
+                await instance.connect(inv2Address).offset(500000000000000000n, 1);
               });
 
               it("Supporter balance must be 99500000000000000000", async () => {
@@ -192,7 +204,7 @@ describe("SupporterRules", () => {
 
             context("when burn 1000000000000000000 tokens", () => {
               beforeEach(async () => {
-                await instance.connect(inv1Address).burnTokensCalculator(1000000000000000000n, 1);
+                await instance.connect(inv1Address).offset(1000000000000000000n, 1);
               });
 
               it("Supporter balance must be 99000000000000000000", async () => {
@@ -216,7 +228,7 @@ describe("SupporterRules", () => {
 
             context("when burn 500000000000000000 tokens", () => {
               beforeEach(async () => {
-                await instance.connect(inv1Address).burnTokensCalculator(500000000000000000n, 1);
+                await instance.connect(inv1Address).offset(500000000000000000n, 1);
               });
 
               it("Supporter balance must be 99500000000000000000", async () => {
@@ -245,7 +257,7 @@ describe("SupporterRules", () => {
             await communityRules.addInvitation(inv1Address, inv2Address, userTypes.Supporter);
             await addSupporter("Supporter B", inv2Address);
             await transferTokensTo(inv2Address, 100000000000000000000n);
-            await instance.connect(inv2Address).burnTokensCalculator(1000000000000000000n, 10);
+            await instance.connect(inv2Address).offset(1000000000000000000n, 10);
           });
 
           context("when burn 1000000000000000000 tokens", () => {
@@ -260,19 +272,19 @@ describe("SupporterRules", () => {
 
       context("when amount is equal zero", () => {
         it("should return error", async () => {
-          await expect(instance.connect(inv1Address).burnTokensCalculator(0, 0)).to.be.revertedWith("Amount invalid");
+          await expect(instance.connect(inv1Address).offset(0, 0)).to.be.revertedWith("Amount invalid");
         });
       });
     });
 
     context("when msg.sender is not SUPPORTER", () => {
       it("should return error", async () => {
-        await expect(instance.connect(inv1Address).burnTokensCalculator(1, 0)).to.be.revertedWith("Only supporters");
+        await expect(instance.connect(inv1Address).offset(1, 0)).to.be.revertedWith("Only supporters");
       });
     });
   });
 
-  describe("#burnTokensPublication", () => {
+  describe("#publish", () => {
     context("when msg.sender is SUPPORTER", () => {
       beforeEach(async () => {
         await addSupporter("Supporter A", inv1Address);
@@ -289,7 +301,7 @@ describe("SupporterRules", () => {
 
             context("when burn 1000000000000000000 tokens", () => {
               beforeEach(async () => {
-                await instance.connect(inv2Address).burnTokensPublication("1000000000000000000", "text", "text");
+                await instance.connect(inv2Address).publish("1000000000000000000", "text", "text");
               });
 
               it("Supporter balance must be 99000000000000000000", async () => {
@@ -323,7 +335,7 @@ describe("SupporterRules", () => {
 
             context("when burn 500000000000000000 tokens", () => {
               beforeEach(async () => {
-                await instance.connect(inv2Address).burnTokensPublication(500000000000000000n, "text", "text");
+                await instance.connect(inv2Address).publish(500000000000000000n, "text", "text");
               });
 
               it("Supporter balance must be 99500000000000000000", async () => {
@@ -350,7 +362,7 @@ describe("SupporterRules", () => {
 
             context("when burn 1000000000000000000 tokens", () => {
               beforeEach(async () => {
-                await instance.connect(inv1Address).burnTokensPublication(1000000000000000000n, "text", "text");
+                await instance.connect(inv1Address).publish(1000000000000000000n, "text", "text");
               });
 
               it("Supporter balance must be 99000000000000000000", async () => {
@@ -368,7 +380,7 @@ describe("SupporterRules", () => {
 
             context("when burn 500000000000000000 tokens", () => {
               beforeEach(async () => {
-                await instance.connect(inv1Address).burnTokensPublication(500000000000000000n, "text", "text");
+                await instance.connect(inv1Address).publish(500000000000000000n, "text", "text");
               });
 
               it("Supporter balance must be 99500000000000000000", async () => {
@@ -389,27 +401,21 @@ describe("SupporterRules", () => {
 
       context("when amount is equal zero", () => {
         it("should return error", async () => {
-          await expect(instance.connect(inv1Address).burnTokensPublication(0, "text", "text")).to.be.revertedWith(
-            "Amount invalid"
-          );
+          await expect(instance.connect(inv1Address).publish(0, "text", "text")).to.be.revertedWith("Amount invalid");
         });
       });
 
       context("when amount is below one and more than zero", () => {
         it("should return error", async () => {
           await transferTokensTo(inv1Address, "100000000000000000000");
-          await expect(instance.connect(inv1Address).burnTokensPublication(1, "text", "text")).to.be.revertedWith(
-            "Amount invalid"
-          );
+          await expect(instance.connect(inv1Address).publish(1, "text", "text")).to.be.revertedWith("Amount invalid");
         });
       });
     });
 
     context("when msg.sender is not SUPPORTER", () => {
       it("should return error", async () => {
-        await expect(instance.connect(inv1Address).burnTokensPublication(1, "text", "text")).to.be.revertedWith(
-          "Only supporters"
-        );
+        await expect(instance.connect(inv1Address).publish(1, "text", "text")).to.be.revertedWith("Only supporters");
       });
     });
   });


### PR DESCRIPTION
Renamed functions to offset and publish. Added logic to map the offsets ids and wallets, to behave similar to the publish function, to appear at the feed page. 