### PR TITLE
fix calculatorItem map problem

### DIFF
--- a/contracts/SupporterRules.sol
+++ b/contracts/SupporterRules.sol
@@ -103,7 +103,7 @@ contract SupporterRules {
 
     if (calculatorItemId > 0) {
       CalculatorItem memory calculatorItem = researcherRules.getCalculatorItem(calculatorItemId);
-      if (calculatorItem.id > 0) calculatorItemCertificates[msg.sender][calculatorItemId] = amountBurn;
+      if (calculatorItem.id > 0) calculatorItemCertificates[msg.sender][calculatorItemId] += amountBurn;
     }
 
     offsets[id] = Offset(msg.sender, block.number, amountBurn, calculatorItemId);

--- a/test/SupporterRules.test.js
+++ b/test/SupporterRules.test.js
@@ -290,13 +290,13 @@ describe("SupporterRules", () => {
               beforeEach(async () => {
                 await instance.connect(inv1Address).offset(1000000000000000000n, 1);
                 await instance.connect(inv1Address).offset(1000000000000000000n, 1);
-                await instance.connect(inv1Address).offset(500000000000000000n, 1);
+                await instance.connect(inv1Address).offset(1500000000000000000n, 1);
               });
 
               it("calculatorItemCertificates must sum all offsets", async () => {
                 const value = await instance.calculatorItemCertificates(inv1Address, 1);
 
-                expect(value).to.equal(2500000000000000000n);
+                expect(value).to.equal(3500000000000000000n);
               });
             });
           });

--- a/test/SupporterRules.test.js
+++ b/test/SupporterRules.test.js
@@ -285,6 +285,20 @@ describe("SupporterRules", () => {
                 expect(value).to.equal(500000000000000000n);
               });
             });
+
+            context("when burn multiple times", () => {
+              beforeEach(async () => {
+                await instance.connect(inv1Address).offset(1000000000000000000n, 1);
+                await instance.connect(inv1Address).offset(1000000000000000000n, 1);
+                await instance.connect(inv1Address).offset(500000000000000000n, 1);
+              });
+
+              it("calculatorItemCertificates must sum all offsets", async () => {
+                const value = await instance.calculatorItemCertificates(inv1Address, 1);
+
+                expect(value).to.equal(2500000000000000000n);
+              });
+            });
           });
         });
 


### PR DESCRIPTION
When a new offset was done, it was replacing the mapping with the amoutBurn. It must sum instead of replacing.