### PR TITLE
add blocksToAccept logic

### DIFF
--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -149,6 +149,7 @@ contract InspectionRules is Callable {
     require(inspection.status == InspectionStatus.OPEN, "This inspection is not OPEN");
     require(acceptInspectionDelayBlocksPassed(inspection), "Wait inspection delay blocks");
     require(beforeAcceptHaveSecurityBlocksToVote(), "Wait until next era to accept");
+    require(inspectorRules.canAcceptInspection(msg.sender), "Wait to accept");
 
     inspection.status = InspectionStatus.ACCEPTED;
     inspection.acceptedAt = block.number;

--- a/contracts/InspectorRules.sol
+++ b/contracts/InspectorRules.sol
@@ -41,6 +41,8 @@ contract InspectorRules is Callable {
   /// @notice Max allowed giveUps before block
   uint256 private constant MAX_GIVEUPS = 3;
 
+  uint256 public immutable blocksToAccept = 6000;
+
   constructor(address communityRulesAddress, address inspectorPoolAddress, uint256 maxPenalties_) {
     communityRules = CommunityRules(communityRulesAddress);
     inspectorPool = InspectorPool(inspectorPoolAddress);
@@ -67,6 +69,7 @@ contract InspectorRules is Callable {
       msg.sender,
       name,
       proofPhoto,
+      0,
       0,
       0,
       0,
@@ -137,6 +140,7 @@ contract InspectorRules is Callable {
    */
   function incrementInspections(address addr) private returns (uint256) {
     inspectors[addr].totalInspections++;
+    inspectors[addr].lastRealizedAt = block.number;
 
     addLevel(addr);
 
@@ -247,5 +251,13 @@ contract InspectorRules is Callable {
    */
   function isInspectorValid(address addr) public view returns (bool) {
     return inspectors[addr].giveUps < MAX_GIVEUPS;
+  }
+
+  function canAcceptInspection(address addr) public view returns (bool) {
+    uint256 lastRealizedAt = inspectors[addr].lastRealizedAt;
+
+    if (lastRealizedAt <= 0) return true;
+
+    return block.number > lastRealizedAt + blocksToAccept;
   }
 }

--- a/contracts/types/InspectorTypes.sol
+++ b/contracts/types/InspectorTypes.sol
@@ -24,6 +24,7 @@ struct Inspector {
   uint256 totalInspections;
   uint256 giveUps;
   uint256 lastAcceptedAt;
+  uint256 lastRealizedAt;
   uint256 lastInspection;
   Pool pool;
   uint256 createdAt;

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -64,6 +64,7 @@ describe("InspectionRules", () => {
     allowedInitialRequests: 1,
     acceptInspectionDelayBlocks: 5,
     securityBlocksToValidatorAnalysis: 100,
+    blocksToAccept: 6000,
   };
 
   const addRegenerator = async (name, from) => {
@@ -662,10 +663,16 @@ describe("InspectionRules", () => {
               beforeEach(async () => {
                 await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
                 await realizeInspection(1, "", treesResultValue, biodiversityResultValue, inspectorAddress);
-                await acceptInspection(2, inspectorAddress);
+              });
+
+              it("should return error when try to accept another inspection before wait blocks", async () => {
+                await expect(acceptInspection(2, inspectorAddress)).to.be.revertedWith("Wait to accept");
               });
 
               it("should accept inspection with success after finishing previous one", async () => {
+                await advanceBlock(sintropArgs.blocksToAccept);
+                await acceptInspection(2, inspectorAddress);
+
                 const inspection = await instance.getInspection(2);
 
                 expect(inspection.status).to.equal(STATUS.accepted);

--- a/test/InspectorRules.test.js
+++ b/test/InspectorRules.test.js
@@ -61,6 +61,7 @@ describe("InspectorRules", () => {
       expect(inspector.giveUps).to.equal("0");
       expect(inspector.lastAcceptedAt).to.equal("0");
       expect(inspector.lastInspection).to.equal("0");
+      expect(inspector.lastRealizedAt).to.equal("0");
     });
   });
 


### PR DESCRIPTION
Add logic to avoid an inspector to accept several inspections in sequence by adding a rule to only allow after some blocks. 