### PR TITLE
change RC from kg to grams

### DIFF
--- a/contracts/RegenerationCreditImpact.sol
+++ b/contracts/RegenerationCreditImpact.sol
@@ -21,14 +21,14 @@ contract RegenerationCreditImpact {
   uint256 public constant IMPACT_DECIMALS = 10 ** 32;
 
   /**
-   * @notice [kg]
-   * This constant estimates an average carbon sequestration of 100 kg per tree, palm tree and other plants with more than 5cm in diameter recorded by inspectors.
+   * @notice [g]
+   * This constant estimates an average carbon sequestration of 100000g (or 100kg) per tree, palm tree and other plants with over 3cm in diameter and 1 meter high recorded by inspectors.
    * In practice, it is not so simple to make this relationship, as the actual amount of carbon sequestered will vary from species to species,
    * from biome to biome, from soil to soil, from management to management and from each geolocation.
    * However, we need to standardize this value to simplify and allow the decentralized certification system to occur.
-   * This result was obtained by estimating that, on average, each tree/plant sequesters 10 kg of carbon per year, living an average of 10 years.
+   * This result was obtained by estimating that, on average, each tree/plant sequesters 10 kg of carbon per year, living an average of 10 years. With the result expressed in grams [g].
    */
-  uint256 public constant CARBON_PER_TREE = 100;
+  uint256 public constant CARBON_PER_TREE = 100000;
 
   RegenerationCredit internal regenerationCredit;
   InspectionRules internal inspectionRules;
@@ -62,7 +62,7 @@ contract RegenerationCreditImpact {
 
   /**
    * @notice Function to calculate the total carbon impact of the system.
-   * @return uint256 Kg of carbon [kg]
+   * @return uint256 Grams of carbon [g]
    */
   function totalCarbonImpact() public view returns (uint256) {
     if (inspectionRules.realizedInspectionsCount() == 0) return 0;

--- a/contracts/ResearcherRules.sol
+++ b/contracts/ResearcherRules.sol
@@ -319,7 +319,7 @@ contract ResearcherRules is Callable, Invitable {
    * @param title CalculatorItem title
    * @param unit Unit of the item. Exapmle: liters, kwh, kg
    * @param justification Item result justification
-   * @param carbonImpact Kg of carbon per unit [kg]
+   * @param carbonImpact Grams of carbon per unit [g]
    */
   function addCalculatorItem(
     string memory title,

--- a/contracts/types/ResearcherTypes.sol
+++ b/contracts/types/ResearcherTypes.sol
@@ -71,7 +71,7 @@ struct Research {
  * @param title Item title
  * @param unit Item unit. [Example: Kg, L, kwh]
  * @param justification Justification of the result provided
- * @param carbonImpact Impact of each item unit in carbon. [kg]
+ * @param carbonImpact Impact of each item unit in carbon. [g]
  */
 struct CalculatorItem {
   uint256 id;

--- a/test/RegenerationCreditImpact.test.js
+++ b/test/RegenerationCreditImpact.test.js
@@ -372,10 +372,10 @@ describe("RegenerationCreditImpact", () => {
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
             });
 
-            it("must returnstotalCarbonImpact equal 1000", async () => {
+            it("must returnstotalCarbonImpact equal 1000000", async () => {
               const totalCarbonImpact = await instance.totalCarbonImpact();
 
-              expect(totalCarbonImpact).to.equal(1000);
+              expect(totalCarbonImpact).to.equal(1000000);
             });
           });
 
@@ -386,10 +386,10 @@ describe("RegenerationCreditImpact", () => {
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
             });
 
-            it("must returnstotalCarbonImpact equal 3200", async () => {
+            it("must returnstotalCarbonImpact equal 3200000", async () => {
               const totalCarbonImpact = await instance.totalCarbonImpact();
 
-              expect(totalCarbonImpact).to.equal(3200);
+              expect(totalCarbonImpact).to.equal(3200000);
             });
           });
         });
@@ -444,10 +444,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(5, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector5Address);
           });
 
-          it("must returnstotalCarbonImpact equal 17400", async () => {
+          it("must returnstotalCarbonImpact equal 17400000", async () => {
             const totalCarbonImpact = await instance.totalCarbonImpact();
 
-            expect(totalCarbonImpact).to.equal(17400);
+            expect(totalCarbonImpact).to.equal(17400000);
           });
         });
 
@@ -483,10 +483,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(3, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector3Address);
           });
 
-          it("must returnstotalCarbonImpact equal 8800", async () => {
+          it("must returnstotalCarbonImpact equal 8800000", async () => {
             const totalCarbonImpact = await instance.totalCarbonImpact();
 
-            expect(totalCarbonImpact).to.equal(8800);
+            expect(totalCarbonImpact).to.equal(8800000);
           });
         });
       });
@@ -1040,10 +1040,10 @@ describe("RegenerationCreditImpact", () => {
                 await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
               });
 
-              it("must returns carbonPerToken equal 66666666", async () => {
+              it("must returns carbonPerToken equal 66666666666", async () => {
                 const carbonPerToken = await instance.carbonPerToken();
 
-                expect(carbonPerToken).to.equal(66666666);
+                expect(carbonPerToken).to.equal(66666666666);
               });
             });
 
@@ -1057,10 +1057,10 @@ describe("RegenerationCreditImpact", () => {
                 await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
               });
 
-              it("must returns carbonPerToken equal 111111111", async () => {
+              it("must returns carbonPerToken equal 111111111111", async () => {
                 const carbonPerToken = await instance.carbonPerToken();
 
-                expect(carbonPerToken).to.equal(111111111);
+                expect(carbonPerToken).to.equal(111111111111);
               });
             });
           });
@@ -1072,10 +1072,10 @@ describe("RegenerationCreditImpact", () => {
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
             });
 
-            it("must returnstotalTreesImpact equal 213333333", async () => {
+            it("must returnstotalTreesImpact equal 213333333333", async () => {
               const carbonPerToken = await instance.carbonPerToken();
 
-              expect(carbonPerToken).to.equal(213333333);
+              expect(carbonPerToken).to.equal(213333333333);
             });
           });
         });
@@ -1130,10 +1130,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(5, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector5Address);
           });
 
-          it("must returns carbonPerToken equal 1160000000", async () => {
+          it("must returns carbonPerToken equal 1160000000000", async () => {
             const carbonPerToken = await instance.carbonPerToken();
 
-            expect(carbonPerToken).to.equal(1160000000);
+            expect(carbonPerToken).to.equal(1160000000000);
           });
         });
 
@@ -1169,10 +1169,10 @@ describe("RegenerationCreditImpact", () => {
             await realizeInspection(3, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector3Address);
           });
 
-          it("must returns carbonPerToken equal 586666666", async () => {
+          it("must returns carbonPerToken equal 586666666666", async () => {
             const carbonPerToken = await instance.carbonPerToken();
 
-            expect(carbonPerToken).to.equal(586666666);
+            expect(carbonPerToken).to.equal(586666666666);
           });
         });
       });

--- a/test/SupporterRules.test.js
+++ b/test/SupporterRules.test.js
@@ -23,7 +23,7 @@ describe("SupporterRules", () => {
   };
 
   const addCalculatorItem = async (from) => {
-    await researcherRules.connect(from).addCalculatorItem("title", "kg", "justification", 1);
+    await researcherRules.connect(from).addCalculatorItem("title", "g", "justification", 1);
   };
 
   const reseacherPoolArgs = {


### PR DESCRIPTION
Update of the Regeneration Credit from kg to grams. The objective of this change is to avoid losing integers since solidity use only integers.

With kg, a calculator item, let's say gasoline, with the impact of 2,6 kg of carbon each liter, would be registered as 2. Now the same item must be registered as 2600 grams of carbon each item, the result can be much more precise.

It affects all logic, the RC now is expressed in grams. 