### PR TITLE
limit delation to not allow supporters

### DIFF
--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -166,6 +166,7 @@ contract CommunityRules is Ownable, Callable {
    */
   function addDelation(address addr, string memory title, string memory testimony) public {
     require(users[msg.sender] != UserType.UNDEFINED, "Caller must be registered");
+    require(users[msg.sender] != UserType.SUPPORTER, "Not allowed to supporters");
     require(users[addr] != UserType.UNDEFINED, "User must be registered");
 
     delations[addr].push(Delation(delationsCount + 1, msg.sender, addr, title, testimony));

--- a/test/CommunityRules.test.js
+++ b/test/CommunityRules.test.js
@@ -494,6 +494,16 @@ describe("CommunityRules", function () {
         await expect(addDelation(user1Address, user2Address)).to.be.revertedWith("Caller must be registered");
       });
     });
+
+    context("when user2 (informer) is a supporter", () => {
+      it("should return error message", async () => {
+        await addInvitation(owner, user1Address, userTypes.Regenerator, owner);
+        await addUser(user1Address, userTypes.Regenerator, owner);
+        await addUser(user2Address, userTypes.Supporter, owner);
+
+        await expect(addDelation(user1Address, user2Address)).to.be.revertedWith("Not allowed to supporters");
+      });
+    });
   });
 
   describe("#getUserDelations", () => {


### PR DESCRIPTION
With this PR, supporters are not going to be allowed to publish a delation. 