### PR TITLE
refact-activistDelay

### DIFF
--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -46,7 +46,7 @@ contract CommunityRules is Ownable, Callable {
     uint256 developerProportionality,
     uint256 contributorProportionality
   ) {
-    userTypeSettings[UserType.SUPPORTER] = UserTypeSetting(0, false, false, 300, false);
+    userTypeSettings[UserType.SUPPORTER] = UserTypeSetting(0, false, false, 150, false);
     userTypeSettings[UserType.REGENERATOR] = UserTypeSetting(0, false, true, 0, false);
     userTypeSettings[UserType.INSPECTOR] = UserTypeSetting(inspectorProportionality, true, true, 0, false);
     userTypeSettings[UserType.ACTIVIST] = UserTypeSetting(activistProportionality, false, true, 100000, true);

--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -46,6 +46,7 @@ contract CommunityRules is Ownable, Callable {
     uint256 developerProportionality,
     uint256 contributorProportionality
   ) {
+    userTypeSettings[UserType.SUPPORTER] = UserTypeSetting(0, false, false, 100, false);
     userTypeSettings[UserType.REGENERATOR] = UserTypeSetting(0, false, true, 0, false);
     userTypeSettings[UserType.INSPECTOR] = UserTypeSetting(inspectorProportionality, true, true, 0, false);
     userTypeSettings[UserType.ACTIVIST] = UserTypeSetting(activistProportionality, false, true, 100000, true);

--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -46,7 +46,7 @@ contract CommunityRules is Ownable, Callable {
     uint256 developerProportionality,
     uint256 contributorProportionality
   ) {
-    userTypeSettings[UserType.SUPPORTER] = UserTypeSetting(0, false, false, 100, false);
+    userTypeSettings[UserType.SUPPORTER] = UserTypeSetting(0, false, false, 300, false);
     userTypeSettings[UserType.REGENERATOR] = UserTypeSetting(0, false, true, 0, false);
     userTypeSettings[UserType.INSPECTOR] = UserTypeSetting(inspectorProportionality, true, true, 0, false);
     userTypeSettings[UserType.ACTIVIST] = UserTypeSetting(activistProportionality, false, true, 100000, true);

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -17,6 +17,7 @@ import { UserType } from "./types/CommunityTypes.sol";
  * @notice This contract manages the rules and logic for users to invite others into the community.
  */
 contract InvitationRules is Ownable {
+  
   // --- State Variables ---
 
   /// @notice Relationship between address and last general invitation blockNumber.
@@ -24,6 +25,9 @@ contract InvitationRules is Ownable {
 
   /// @notice Relationship between activist address and last activist invitation blockNumber (for Regenerator/Inspector).
   mapping(address => uint256) public lastInviteActivist;
+
+  /// @notice Relationship between supporter address and last supporter invitation blockNumber (for Regenerator/Inspector).
+  mapping(address => uint256) public lastInviteSupporter;
 
   /// @notice Maps which UserType (inviter) can invite which other UserTypes (invited).
   /// @dev The key is the inviter's UserType, and the value is a mapping from UserType (invited) to a boolean (true if allowed).
@@ -49,6 +53,9 @@ contract InvitationRules is Ownable {
 
   /// @notice The minimum number of blocks an activist needs to wait to invite Regenerators or Inspectors again.
   uint256 public constant activistDelayBlocks = 1000;
+
+  /// @notice The minimum number of blocks an supporter needs to wait to invite a Supporter again.
+  uint256 public constant supporterDelayBlocks = 500;  
 
   // --- Events ---
 
@@ -148,6 +155,24 @@ contract InvitationRules is Ownable {
     emit UserInvited(msg.sender, invited, userType, block.number);
   }
 
+  function inviteSupporter(address invited, UserType userType) public {
+    // Checks if the caller is a supporter.
+    require(communityRules.userTypeIs(UserType.SUPPORTER, msg.sender), "Only to supporters");
+    // Checks if the invited user type is Supporter.
+    require(userType == UserType.SUPPORTER, "Only supporters");
+    // Checks if the specific invitation delay for supporters has been reached.
+    require(invitationDelaySupporter(), "Invite delay not reached");
+
+    // Updates the last activist invitation block for the inviter.
+    lastInviteSupporter[msg.sender] = block.number;
+
+    // Adds the invitation to the CommunityRules contract.
+    communityRules.addInvitation(msg.sender, invited, userType);
+
+    // Emits an event to log the invitation.
+    emit UserInvited(msg.sender, invited, userType, block.number);    
+  }  
+
   // --- Helper Functions (Internal/View) ---
 
   /**
@@ -186,6 +211,14 @@ contract InvitationRules is Ownable {
   function invitationDelayActivist() internal view returns (bool) {
     return hasInvitationDelayPassed(lastInviteActivist[msg.sender], activistDelayBlocks);
   }
+
+  /**
+   * @dev Calculates if the supporter has reached the specific invitation delay for supporters.
+   * @return bool True if the supporter waited the delay blocks, false otherwise.
+   */
+  function invitationDelaySupporter() internal view returns (bool) {
+    return hasInvitationDelayPassed(lastInviteSupporter[msg.sender], supporterDelayBlocks);
+  }  
 
   /**
    * @dev Helper function to calculate if an invitation delay has been met.

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -13,16 +13,22 @@ import { UserType } from "./types/CommunityTypes.sol";
 /**
  * @author Sintrop
  * @title InvitationRules
- * @dev Manage logic to allow users invite others
+ * @dev Manages the logic to allow users to invite others to the community.
+ * @notice This contract manages the rules and logic for users to invite others into the community.
  */
 contract InvitationRules is Ownable {
-  /// @notice Relationship between address and last invitation blockNumber
+
+  // --- State Variables ---
+    
+  /// @notice Relationship between address and last general invitation blockNumber.
   mapping(address => uint256) public lastInviteBlocks;
 
-  /// @notice Relationship between address and last activist regenerator or inspector invitation blockNumber
+  /// @notice Relationship between activist address and last activist invitation blockNumber (for Regenerator/Inspector).
   mapping(address => uint256) public lastInviteActivist;
 
-  /// @notice Relationship between which userType can invite who
+
+  /// @notice Maps which UserType (inviter) can invite which other UserTypes (invited).
+  /// @dev The key is the inviter's UserType, and the value is a mapping from UserType (invited) to a boolean (true if allowed).
   mapping(UserType => UserType) public canBeInviteds;
 
   /// @notice CommunityRules contract address
@@ -43,8 +49,21 @@ contract InvitationRules is Ownable {
   /// @notice ValidationRules contract address
   ValidationRules internal validationRules;
 
-  uint256 public immutable activistDelayBlocks = 1000;
+  /// @notice The minimum number of blocks an activist needs to wait to invite Regenerators or Inspectors again.
+  uint256 public constant activistDelayBlocks = 1000;
 
+  // --- Constructor ---
+
+  /**
+   * @notice Constructor that initializes the addresses of the rule contracts and defines invitation permissions.
+   * @dev Ensures that all contract addresses are valid (not null).
+   * @param communityRulesAddress Address of the CommunityRules contract.
+   * @param researcherRulesAddress Address of the ResearcherRules contract.
+   * @param developerRulesAddress Address of the DeveloperRules contract.
+   * @param activistRulesAddress Address of the ActivistRules contract.
+   * @param contributorRulesAddress Address of the ContributorRules contract.
+   * @param validationRulesAddress Address of the ValidationRules contract.
+   */
   constructor(
     address communityRulesAddress,
     address researcherRulesAddress,
@@ -60,6 +79,7 @@ contract InvitationRules is Ownable {
     contributorRules = ContributorRules(contributorRulesAddress);
     validationRules = ValidationRules(validationRulesAddress);
 
+    // Definition of invitation permissions: who can invite whom
     canBeInviteds[UserType.ACTIVIST] = UserType.ACTIVIST;
     canBeInviteds[UserType.INSPECTOR] = UserType.ACTIVIST;
     canBeInviteds[UserType.REGENERATOR] = UserType.ACTIVIST;
@@ -69,23 +89,54 @@ contract InvitationRules is Ownable {
     canBeInviteds[UserType.CONTRIBUTOR] = UserType.CONTRIBUTOR;
   }
 
+  // --- Core Logic Functions ---
+
   /**
-   * @dev Allows a user to attempt to invite another wallet to the community
-   * @notice Most active users can invite new users to the system
-   * @param invited Invited address
-   * @param userType Invited type
+   * @dev Allows a user to attempt to invite another wallet to the community.
+   * @notice Most active users can invite new users to the system, respecting delay and type rules.
+   * @param invited The address of the wallet to be invited.
+   * @param userType The user type to which the invited user will be assigned.
    */
   function invite(address invited, UserType userType) public {
     UserType msgSenderUserType = communityRules.getUser(msg.sender);
 
+    // Checks if the inviter has general permission to send invitations.
     require(canSendInvite(msgSenderUserType), "Only most active users allowed to invite");
+    // Checks if the invitation delay for the inviter's type has been reached.
     require(invitationDelayReached(msgSenderUserType), "Invite delay not reached");
+    // Checks if the inviter can invite the specified user type.
     require(canBeInviteds[userType] == msgSenderUserType, "Can't invite this type");
 
+    // Updates the last invitation block for the inviter.
     lastInviteBlocks[msg.sender] = block.number;
 
+    // Adds the invitation to the CommunityRules contract.
     communityRules.addInvitation(msg.sender, invited, userType);
   }
+
+  /**
+   * @dev Allows an activist to invite Regenerators or Inspectors to the community.
+   * @notice Activists can invite Regenerators or Inspectors to the system, respecting the specific activist delay.
+   * @param invited The address of the wallet to be invited.
+   * @param userType The user type to which the invited user will be assigned (must be REGENERATOR or INSPECTOR).
+   */
+  function inviteRegeneratorInspector(address invited, UserType userType) public {
+
+    // Checks if the caller is an activist.
+    require(communityRules.userTypeIs(UserType.ACTIVIST, msg.sender), "Only to activists");
+    // Checks if the invited user type is Regenerator or Inspector.
+    require(userType == UserType.REGENERATOR || userType == UserType.INSPECTOR, "Only regenerators or inspectors");
+    // Checks if the specific invitation delay for activists has been reached.
+    require(invitationDelayActivist(), "Invite delay not reached");
+
+    // Updates the last activist invitation block for the inviter.
+    lastInviteActivist[msg.sender] = block.number;
+
+    // Adds the invitation to the CommunityRules contract.
+    communityRules.addInvitation(msg.sender, invited, userType);
+  }
+
+  // --- Helper Functions (Internal/View) ---
 
   /**
    * @dev Based on the inviter userType, this function sends to the correct contract to check if user can invite
@@ -106,42 +157,44 @@ contract InvitationRules is Ownable {
   }
 
   /**
-   * @dev Allows an activist to invite others to the community
-   * @notice Activists can invite regenerators or inspectors to the system
-   * @param invited Invited address
-   * @param userType Invited type
-   */
-  function inviteRegeneratorInspector(address invited, UserType userType) public {
-    require(communityRules.userTypeIs(UserType.ACTIVIST, msg.sender), "Only to activists");
-    require(userType == UserType.REGENERATOR || userType == UserType.INSPECTOR, "Only regenerators or inspectors");
-    require(invitationDelayActivist(), "Invite delay not reached");
-
-    lastInviteActivist[msg.sender] = block.number;
-
-    communityRules.addInvitation(msg.sender, invited, userType);
-  }
-
-  /**
-   * @dev Allows owner to invite another wallet to the community
-   * @param invited Invited address
-   * @param userType Invited type
-   */
-  function onlyOwnerInvite(address invited, UserType userType) public onlyOwner {
-    communityRules.addInvitation(msg.sender, invited, userType);
-  }
-
-  /**
-   * @dev Calculate if user reached invitation delay
-   * @param userType Invited type
-   * @return bool True if user waited delay blocks
+   * @dev Calculates if the user has reached the general invitation delay based on their user type.
+   * @param userType The user type of the inviter.
+   * @return bool True if the user waited the delay blocks, false otherwise.
    */
   function invitationDelayReached(UserType userType) internal view returns (bool) {
     uint256 delayBlocks = communityRules.getUserTypeSettings(userType).invitationDelayBlocks;
 
-    return lastInviteBlocks[msg.sender] <= 0 || block.number - lastInviteBlocks[msg.sender] >= delayBlocks;
+    return hasInvitationDelayPassed(lastInviteBlocks[msg.sender], delayBlocks);
   }
 
+  /**
+   * @dev Calculates if the activist has reached the specific invitation delay for activists.
+   * @return bool True if the activist waited the delay blocks, false otherwise.
+   */
   function invitationDelayActivist() internal view returns (bool) {
-    return lastInviteActivist[msg.sender] <= 0 || block.number - lastInviteActivist[msg.sender] >= activistDelayBlocks;
-  }
+    return hasInvitationDelayPassed(lastInviteActivist[msg.sender], activistDelayBlocks);
+  } 
+
+  /**
+   * @dev Helper function to calculate if an invitation delay has been met.
+   * @param lastInviteBlock The block number of the last invitation.
+   * @param delayBlocks The number of blocks that need to be waited.
+   * @return bool True if the delay has been met, false otherwise.
+   */
+  function hasInvitationDelayPassed(uint256 lastInviteBlock, uint256 delayBlocks) internal view returns (bool) {
+    return lastInviteBlock == 0 || block.number - lastInviteBlock >= delayBlocks;
+  }  
+
+  // --- Deploy Functions ---
+
+  /**
+   * @dev Allows the contract owner to invite a wallet to the community.
+   * @notice The owner can invite any user type without delay or type restrictions.
+   * If ownership is renounced, no wallet will be able to call this function.
+   * @param invited The address of the wallet to be invited.
+   * @param userType The user type to which the invited user will be assigned.
+   */
+  function onlyOwnerInvite(address invited, UserType userType) public onlyOwner {
+    communityRules.addInvitation(msg.sender, invited, userType);
+  }  
 }

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -17,7 +17,6 @@ import { UserType } from "./types/CommunityTypes.sol";
  * @notice This contract manages the rules and logic for users to invite others into the community.
  */
 contract InvitationRules is Ownable {
-  
   // --- State Variables ---
 
   /// @notice Relationship between address and last general invitation blockNumber.
@@ -55,7 +54,7 @@ contract InvitationRules is Ownable {
   uint256 public constant activistDelayBlocks = 1000;
 
   /// @notice The minimum number of blocks an supporter needs to wait to invite a Supporter again.
-  uint256 public constant supporterDelayBlocks = 500;  
+  uint256 public constant supporterDelayBlocks = 500;
 
   // --- Events ---
 
@@ -170,8 +169,8 @@ contract InvitationRules is Ownable {
     communityRules.addInvitation(msg.sender, invited, userType);
 
     // Emits an event to log the invitation.
-    emit UserInvited(msg.sender, invited, userType, block.number);    
-  }  
+    emit UserInvited(msg.sender, invited, userType, block.number);
+  }
 
   // --- Helper Functions (Internal/View) ---
 
@@ -218,7 +217,7 @@ contract InvitationRules is Ownable {
    */
   function invitationDelaySupporter() internal view returns (bool) {
     return hasInvitationDelayPassed(lastInviteSupporter[msg.sender], supporterDelayBlocks);
-  }  
+  }
 
   /**
    * @dev Helper function to calculate if an invitation delay has been met.

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -17,15 +17,13 @@ import { UserType } from "./types/CommunityTypes.sol";
  * @notice This contract manages the rules and logic for users to invite others into the community.
  */
 contract InvitationRules is Ownable {
-
   // --- State Variables ---
-    
+
   /// @notice Relationship between address and last general invitation blockNumber.
   mapping(address => uint256) public lastInviteBlocks;
 
   /// @notice Relationship between activist address and last activist invitation blockNumber (for Regenerator/Inspector).
   mapping(address => uint256) public lastInviteActivist;
-
 
   /// @notice Maps which UserType (inviter) can invite which other UserTypes (invited).
   /// @dev The key is the inviter's UserType, and the value is a mapping from UserType (invited) to a boolean (true if allowed).
@@ -121,7 +119,6 @@ contract InvitationRules is Ownable {
    * @param userType The user type to which the invited user will be assigned (must be REGENERATOR or INSPECTOR).
    */
   function inviteRegeneratorInspector(address invited, UserType userType) public {
-
     // Checks if the caller is an activist.
     require(communityRules.userTypeIs(UserType.ACTIVIST, msg.sender), "Only to activists");
     // Checks if the invited user type is Regenerator or Inspector.
@@ -173,7 +170,7 @@ contract InvitationRules is Ownable {
    */
   function invitationDelayActivist() internal view returns (bool) {
     return hasInvitationDelayPassed(lastInviteActivist[msg.sender], activistDelayBlocks);
-  } 
+  }
 
   /**
    * @dev Helper function to calculate if an invitation delay has been met.
@@ -183,7 +180,7 @@ contract InvitationRules is Ownable {
    */
   function hasInvitationDelayPassed(uint256 lastInviteBlock, uint256 delayBlocks) internal view returns (bool) {
     return lastInviteBlock == 0 || block.number - lastInviteBlock >= delayBlocks;
-  }  
+  }
 
   // --- Deploy Functions ---
 
@@ -196,5 +193,5 @@ contract InvitationRules is Ownable {
    */
   function onlyOwnerInvite(address invited, UserType userType) public onlyOwner {
     communityRules.addInvitation(msg.sender, invited, userType);
-  }  
+  }
 }

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -17,6 +17,7 @@ import { UserType } from "./types/CommunityTypes.sol";
  * @notice This contract manages the rules and logic for users to invite others into the community.
  */
 contract InvitationRules is Ownable {
+
   // --- State Variables ---
 
   /// @notice Relationship between address and last general invitation blockNumber.
@@ -149,7 +150,7 @@ contract InvitationRules is Ownable {
     } else if (userType == UserType.RESEARCHER) {
       return researcherRules.canSendInvite(msg.sender);
     } else {
-      return true;
+      return false;
     }
   }
 

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -25,9 +25,6 @@ contract InvitationRules is Ownable {
   /// @notice Relationship between activist address and last activist invitation blockNumber (for Regenerator/Inspector).
   mapping(address => uint256) public lastInviteActivist;
 
-  /// @notice Relationship between supporter address and last supporter invitation blockNumber (for Regenerator/Inspector).
-  mapping(address => uint256) public lastInviteSupporter;
-
   /// @notice Maps which UserType (inviter) can invite which other UserTypes (invited).
   /// @dev The key is the inviter's UserType, and the value is a mapping from UserType (invited) to a boolean (true if allowed).
   mapping(UserType => UserType) public canBeInviteds;

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -17,7 +17,6 @@ import { UserType } from "./types/CommunityTypes.sol";
  * @notice This contract manages the rules and logic for users to invite others into the community.
  */
 contract InvitationRules is Ownable {
-
   // --- State Variables ---
 
   /// @notice Relationship between address and last general invitation blockNumber.
@@ -50,6 +49,15 @@ contract InvitationRules is Ownable {
 
   /// @notice The minimum number of blocks an activist needs to wait to invite Regenerators or Inspectors again.
   uint256 public constant activistDelayBlocks = 1000;
+
+  // --- Events ---
+
+  /// @notice Event emitted when a user invites another.
+  /// @param inviter The address of the user who made the invitation.
+  /// @param invited The address of the invited user.
+  /// @param invitedType The user type assigned to the invited user.
+  /// @param blockNumber The block number at which the invitation was made.
+  event UserInvited(address indexed inviter, address indexed invited, UserType invitedType, uint256 blockNumber);
 
   // --- Constructor ---
 
@@ -111,6 +119,9 @@ contract InvitationRules is Ownable {
 
     // Adds the invitation to the CommunityRules contract.
     communityRules.addInvitation(msg.sender, invited, userType);
+
+    // Emits an event to log the invitation.
+    emit UserInvited(msg.sender, invited, userType, block.number);
   }
 
   /**
@@ -132,6 +143,9 @@ contract InvitationRules is Ownable {
 
     // Adds the invitation to the CommunityRules contract.
     communityRules.addInvitation(msg.sender, invited, userType);
+
+    // Emits an event to log the invitation.
+    emit UserInvited(msg.sender, invited, userType, block.number);
   }
 
   // --- Helper Functions (Internal/View) ---
@@ -194,5 +208,7 @@ contract InvitationRules is Ownable {
    */
   function onlyOwnerInvite(address invited, UserType userType) public onlyOwner {
     communityRules.addInvitation(msg.sender, invited, userType);
+    // Emits an event to log the invitation.
+    emit UserInvited(msg.sender, invited, userType, block.number);
   }
 }

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -154,24 +154,6 @@ contract InvitationRules is Ownable {
     emit UserInvited(msg.sender, invited, userType, block.number);
   }
 
-  function inviteSupporter(address invited, UserType userType) public {
-    // Checks if the caller is a supporter.
-    require(communityRules.userTypeIs(UserType.SUPPORTER, msg.sender), "Only to supporters");
-    // Checks if the invited user type is Supporter.
-    require(userType == UserType.SUPPORTER, "Only supporters");
-    // Checks if the specific invitation delay for supporters has been reached.
-    require(invitationDelaySupporter(), "Invite delay not reached");
-
-    // Updates the last activist invitation block for the inviter.
-    lastInviteSupporter[msg.sender] = block.number;
-
-    // Adds the invitation to the CommunityRules contract.
-    communityRules.addInvitation(msg.sender, invited, userType);
-
-    // Emits an event to log the invitation.
-    emit UserInvited(msg.sender, invited, userType, block.number);
-  }
-
   // --- Helper Functions (Internal/View) ---
 
   /**
@@ -187,6 +169,8 @@ contract InvitationRules is Ownable {
       return developerRules.canSendInvite(msg.sender);
     } else if (userType == UserType.RESEARCHER) {
       return researcherRules.canSendInvite(msg.sender);
+    } else if (userType == UserType.SUPPORTER) {
+      return true;
     } else {
       return false;
     }
@@ -209,14 +193,6 @@ contract InvitationRules is Ownable {
    */
   function invitationDelayActivist() internal view returns (bool) {
     return hasInvitationDelayPassed(lastInviteActivist[msg.sender], activistDelayBlocks);
-  }
-
-  /**
-   * @dev Calculates if the supporter has reached the specific invitation delay for supporters.
-   * @return bool True if the supporter waited the delay blocks, false otherwise.
-   */
-  function invitationDelaySupporter() internal view returns (bool) {
-    return hasInvitationDelayPassed(lastInviteSupporter[msg.sender], supporterDelayBlocks);
   }
 
   /**

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -19,6 +19,9 @@ contract InvitationRules is Ownable {
   /// @notice Relationship between address and last invitation blockNumber
   mapping(address => uint256) public lastInviteBlocks;
 
+  /// @notice Relationship between address and last activist regenerator or inspector invitation blockNumber
+  mapping(address => uint256) public lastInviteActivist;
+
   /// @notice Relationship between which userType can invite who
   mapping(UserType => UserType) public canBeInviteds;
 
@@ -39,6 +42,8 @@ contract InvitationRules is Ownable {
 
   /// @notice ValidationRules contract address
   ValidationRules internal validationRules;
+
+  uint256 public immutable activistDelayBlocks = 1000;
 
   constructor(
     address communityRulesAddress,
@@ -109,9 +114,9 @@ contract InvitationRules is Ownable {
   function inviteRegeneratorInspector(address invited, UserType userType) public {
     require(communityRules.userTypeIs(UserType.ACTIVIST, msg.sender), "Only to activists");
     require(userType == UserType.REGENERATOR || userType == UserType.INSPECTOR, "Only regenerators or inspectors");
-    require(invitationDelayReached(UserType.ACTIVIST), "Invite delay not reached");
+    require(invitationDelayActivist(), "Invite delay not reached");
 
-    lastInviteBlocks[msg.sender] = block.number;
+    lastInviteActivist[msg.sender] = block.number;
 
     communityRules.addInvitation(msg.sender, invited, userType);
   }
@@ -134,5 +139,9 @@ contract InvitationRules is Ownable {
     uint256 delayBlocks = communityRules.getUserTypeSettings(userType).invitationDelayBlocks;
 
     return lastInviteBlocks[msg.sender] <= 0 || block.number - lastInviteBlocks[msg.sender] >= delayBlocks;
+  }
+
+  function invitationDelayActivist() internal view returns (bool) {
+    return lastInviteActivist[msg.sender] <= 0 || block.number - lastInviteActivist[msg.sender] >= activistDelayBlocks;
   }
 }

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -50,9 +50,6 @@ contract InvitationRules is Ownable {
   /// @notice The minimum number of blocks an activist needs to wait to invite Regenerators or Inspectors again.
   uint256 public constant activistDelayBlocks = 1000;
 
-  /// @notice The minimum number of blocks an supporter needs to wait to invite a Supporter again.
-  uint256 public constant supporterDelayBlocks = 500;
-
   // --- Events ---
 
   /// @notice Event emitted when a user invites another.

--- a/test/InvitationRules.test.js
+++ b/test/InvitationRules.test.js
@@ -520,58 +520,6 @@ describe("InvitationRules", () => {
           });
         });
       });
-
-      context("when supporter send invite", () => {
-        beforeEach(async () => {
-          await addInvitation(owner, user2Address, userTypes.Supporter, owner);
-          await addUser(user2Address, userTypes.Supporter, owner);
-        });
-
-        context("when send to supporter", () => {
-          context("when have a previous invitation", () => {
-            context("when is not recent", () => {
-              beforeEach(async () => {
-                await instance.connect(user2Address).invite(user3Address, userTypes.Supporter);
-                const blocks = await userTypeDelayBlocks(userTypes.Supporter);
-
-                await advanceBlock(blocks);
-              });
-
-              it("invite with success", async () => {
-                await instance.connect(user2Address).invite(user4Address, userTypes.Supporter);
-
-                const invitation = await communityRules.invitations(user4Address);
-
-                expect(invitation.invited).to.equal(user4Address.address);
-              });
-            });
-
-            context("when is recent", () => {
-              beforeEach(async () => {
-                await instance.connect(user2Address).invite(user3Address, userTypes.Supporter);
-              });
-
-              it("invite with success", async () => {
-                await instance.connect(user2Address).invite(user4Address, userTypes.Supporter);
-
-                const invitation = await communityRules.invitations(user4Address);
-
-                expect(invitation.invited).to.equal(user4Address.address);
-              });
-            });
-          });
-
-          context("when do not have a previous invitation", () => {
-            it("invite with success", async () => {
-              await instance.connect(user2Address).invite(user3Address, userTypes.Supporter);
-
-              const invitation = await communityRules.invitations(user3Address);
-
-              expect(invitation.invited).to.equal(user3Address.address);
-            });
-          });
-        });
-      });
     });
   });
 
@@ -632,6 +580,52 @@ describe("InvitationRules", () => {
       });
     });
   });
+
+  describe("#inviteSupporter", () => {
+    beforeEach(async () => {
+      await addUser(user1Address, userTypes.Supporter, owner);
+    });
+
+    context("when invite supporter", () => {
+      context("with supporter", () => {
+        it("should invite supporter with success", async () => {
+          await instance.connect(user1Address).inviteSupporter(user4Address, userTypes.Supporter);
+
+          const invitation = await communityRules.invitations(user4Address);
+
+          expect(invitation.invited).to.equal(user4Address.address);
+        });
+      });
+
+      context("without supporter", () => {
+        it("should revert", async () => {
+          await expect(
+            instance.connect(user2Address).inviteSupporter(user4Address, userTypes.Activist)
+          ).to.be.revertedWith("Only to supporters");
+        });
+      });
+    });
+
+    context("when invite other types", () => {
+      it("should revert", async () => {
+        await expect(
+          instance.connect(user1Address).inviteSupporter(user4Address, userTypes.Activist)
+        ).to.be.revertedWith("Only supporters");
+      });
+    });
+
+    context("when is recent", () => {
+      beforeEach(async () => {
+        await instance.connect(user1Address).inviteSupporter(user4Address, userTypes.Supporter);
+      });
+
+      it("should revert", async () => {
+        await expect(
+          instance.connect(user1Address).inviteSupporter(user5Address, userTypes.Supporter)
+        ).to.be.revertedWith("Invite delay not reached");
+      });
+    });
+  });  
 
   describe("#onlyOwnerInvite", () => {
     context("when invite", () => {

--- a/test/InvitationRules.test.js
+++ b/test/InvitationRules.test.js
@@ -520,6 +520,56 @@ describe("InvitationRules", () => {
           });
         });
       });
+
+      context("when supporter send invite", () => {
+        beforeEach(async () => {
+          await addInvitation(owner, user2Address, userTypes.Supporter, owner);
+          await addUser(user2Address, userTypes.Supporter, owner);
+        });
+
+        context("when send to supporter", () => {
+          context("when have a previous invitation", () => {
+            context("when is not recent", () => {
+              beforeEach(async () => {
+                await instance.connect(user2Address).invite(user3Address, userTypes.Supporter);
+                const blocks = await userTypeDelayBlocks(userTypes.Supporter);
+
+                await advanceBlock(blocks);
+              });
+
+              it("invite with success", async () => {
+                await instance.connect(user2Address).invite(user4Address, userTypes.Supporter);
+
+                const invitation = await communityRules.invitations(user4Address);
+
+                expect(invitation.invited).to.equal(user4Address.address);
+              });
+            });
+
+            context("when is recent", () => {
+              beforeEach(async () => {
+                await instance.connect(user2Address).invite(user3Address, userTypes.Supporter);
+              });
+
+              it("invite with success", async () => {
+                await expect(instance.connect(user2Address).invite(user4Address, userTypes.Supporter)).to.be.revertedWith(
+                  "Invite delay not reached"
+                );
+              });
+            });
+          });
+
+          context("when do not have a previous invitation", () => {
+            it("invite with success", async () => {
+              await instance.connect(user2Address).invite(user3Address, userTypes.Supporter);
+
+              const invitation = await communityRules.invitations(user3Address);
+
+              expect(invitation.invited).to.equal(user3Address.address);
+            });
+          });
+        });
+      });
     });
   });
 
@@ -576,52 +626,6 @@ describe("InvitationRules", () => {
       it("should revert", async () => {
         await expect(
           instance.connect(user2Address).inviteRegeneratorInspector(user5Address, userTypes.Regenerator)
-        ).to.be.revertedWith("Invite delay not reached");
-      });
-    });
-  });
-
-  describe("#inviteSupporter", () => {
-    beforeEach(async () => {
-      await addUser(user1Address, userTypes.Supporter, owner);
-    });
-
-    context("when invite supporter", () => {
-      context("with supporter", () => {
-        it("should invite supporter with success", async () => {
-          await instance.connect(user1Address).inviteSupporter(user4Address, userTypes.Supporter);
-
-          const invitation = await communityRules.invitations(user4Address);
-
-          expect(invitation.invited).to.equal(user4Address.address);
-        });
-      });
-
-      context("without supporter", () => {
-        it("should revert", async () => {
-          await expect(
-            instance.connect(user2Address).inviteSupporter(user4Address, userTypes.Activist)
-          ).to.be.revertedWith("Only to supporters");
-        });
-      });
-    });
-
-    context("when invite other types", () => {
-      it("should revert", async () => {
-        await expect(
-          instance.connect(user1Address).inviteSupporter(user4Address, userTypes.Activist)
-        ).to.be.revertedWith("Only supporters");
-      });
-    });
-
-    context("when is recent", () => {
-      beforeEach(async () => {
-        await instance.connect(user1Address).inviteSupporter(user4Address, userTypes.Supporter);
-      });
-
-      it("should revert", async () => {
-        await expect(
-          instance.connect(user1Address).inviteSupporter(user5Address, userTypes.Supporter)
         ).to.be.revertedWith("Invite delay not reached");
       });
     });

--- a/test/InvitationRules.test.js
+++ b/test/InvitationRules.test.js
@@ -552,9 +552,9 @@ describe("InvitationRules", () => {
               });
 
               it("invite with success", async () => {
-                await expect(instance.connect(user2Address).invite(user4Address, userTypes.Supporter)).to.be.revertedWith(
-                  "Invite delay not reached"
-                );
+                await expect(
+                  instance.connect(user2Address).invite(user4Address, userTypes.Supporter)
+                ).to.be.revertedWith("Invite delay not reached");
               });
             });
           });

--- a/test/InvitationRules.test.js
+++ b/test/InvitationRules.test.js
@@ -625,7 +625,7 @@ describe("InvitationRules", () => {
         ).to.be.revertedWith("Invite delay not reached");
       });
     });
-  });  
+  });
 
   describe("#onlyOwnerInvite", () => {
     context("when invite", () => {


### PR DESCRIPTION
This implementation splits the activistDelay into two different groups. Before it, the same delay was used to invite activist, regenerators and inspectors. The problem is that since now activists are voters, the delay to invite a new acitivst was to short, since the delay to invite regenerators and inspectors need to be short. After it, activists invitation will follow two different delays: the delay to invite activist, and the delay to invite regenerators and inspectors. 