### PR TITLE
refact decreaseLocked

### DIFF
--- a/contracts/ActivistPool.sol
+++ b/contracts/ActivistPool.sol
@@ -84,11 +84,11 @@ contract ActivistPool is Poolable, Blockable, Callable, ReentrancyGuard {
     // If no tokens are to be transferred, return.
     if (numTokens == 0) return;
 
+    regenerationCredit.decreaseLocked(numTokens);
+
     // Transfer the calculated tokens from this contract to the delegate.
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
-
-    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/ActivistPool.sol
+++ b/contracts/ActivistPool.sol
@@ -88,7 +88,7 @@ contract ActivistPool is Poolable, Blockable, Callable, ReentrancyGuard {
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
 
-    regenerationCredit.decreaseLocked(address(this), numTokens);
+    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/ContributorPool.sol
+++ b/contracts/ContributorPool.sol
@@ -88,7 +88,7 @@ contract ContributorPool is Poolable, Blockable, Callable, ReentrancyGuard {
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
 
-    regenerationCredit.decreaseLocked(address(this), numTokens);
+    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/ContributorPool.sol
+++ b/contracts/ContributorPool.sol
@@ -84,11 +84,11 @@ contract ContributorPool is Poolable, Blockable, Callable, ReentrancyGuard {
     // If no tokens are to be transferred, return.
     if (numTokens == 0) return;
 
+    regenerationCredit.decreaseLocked(numTokens);
+
     // Transfer the calculated tokens from this contract to the delegate.
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
-
-    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/DeveloperPool.sol
+++ b/contracts/DeveloperPool.sol
@@ -89,7 +89,7 @@ contract DeveloperPool is Poolable, Blockable, Callable, ReentrancyGuard {
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
 
-    regenerationCredit.decreaseLocked(address(this), numTokens);
+    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/DeveloperPool.sol
+++ b/contracts/DeveloperPool.sol
@@ -85,11 +85,11 @@ contract DeveloperPool is Poolable, Blockable, Callable, ReentrancyGuard {
     // If no tokens are to be transferred, return.
     if (numTokens == 0) return;
 
+    regenerationCredit.decreaseLocked(numTokens);
+
     // Transfer the calculated tokens from this contract to the delegate.
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
-
-    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/InspectorPool.sol
+++ b/contracts/InspectorPool.sol
@@ -84,11 +84,11 @@ contract InspectorPool is Poolable, Blockable, Callable, ReentrancyGuard {
     // If no tokens are to be transferred, return.
     if (numTokens == 0) return;
 
+    regenerationCredit.decreaseLocked(numTokens);
+
     // Transfer the calculated tokens from this contract to the delegate.
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
-
-    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/InspectorPool.sol
+++ b/contracts/InspectorPool.sol
@@ -88,7 +88,7 @@ contract InspectorPool is Poolable, Blockable, Callable, ReentrancyGuard {
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
 
-    regenerationCredit.decreaseLocked(address(this), numTokens);
+    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/RegenerationCredit.sol
+++ b/contracts/RegenerationCredit.sol
@@ -168,15 +168,14 @@ contract RegenerationCredit is ERC20, Ownable, ReentrancyGuard {
   /**
    * @dev Allows a designated "contract pool" to register a new decreaseLocked.
    * @notice Called only by a system pool contract, this function remove the transfered tokens from totalLocked.
-   * @param tokenOwner The address of the contract pool initiating the transfer.
    * @param numTokens The amount of tokens to transfer.
    */
-  function decreaseLocked(address tokenOwner, uint256 numTokens) external mustBeContractPool {
-    require(numTokens <= balanceOf(tokenOwner), "Pool out of balance");
+  function decreaseLocked(uint256 numTokens) external mustBeContractPool {
+    require(numTokens <= balanceOf(msg.sender), "Pool out of balance");
 
     // Update total locked tokens.
     unchecked {
-      if (contractsPools[tokenOwner]) totalLocked_ -= numTokens;
+      if (contractsPools[msg.sender]) totalLocked_ -= numTokens;
     }
   }
 

--- a/contracts/RegenerationCredit.sol
+++ b/contracts/RegenerationCredit.sol
@@ -172,11 +172,9 @@ contract RegenerationCredit is ERC20, Ownable, ReentrancyGuard {
    */
   function decreaseLocked(uint256 numTokens) external mustBeContractPool {
     require(numTokens <= balanceOf(msg.sender), "Pool out of balance");
+    require(numTokens <= totalLocked_, "Cannot decrease more than total locked");
 
-    // Update total locked tokens.
-    unchecked {
-      if (contractsPools[msg.sender]) totalLocked_ -= numTokens;
-    }
+    if (contractsPools[msg.sender]) totalLocked_ -= numTokens;
   }
 
   // --- Private functions ---

--- a/contracts/RegenerationCredit.sol
+++ b/contracts/RegenerationCredit.sol
@@ -114,6 +114,8 @@ contract RegenerationCredit is ERC20, Ownable, ReentrancyGuard {
    * Requirements:
    * - The caller (`msg.sender`) must have `amount` tokens.
    * - `amount` must be greater than 0.
+   * 
+   * Note: This functions uses the token 18 decimals, to burn 1 RC user must write 1000000000000000000.
    *
    * @param amount The amount of tokens to burn from the caller's balance.
    */

--- a/contracts/RegeneratorPool.sol
+++ b/contracts/RegeneratorPool.sol
@@ -88,7 +88,7 @@ contract RegeneratorPool is Poolable, Blockable, Callable, ReentrancyGuard {
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
 
-    regenerationCredit.decreaseLocked(address(this), numTokens);
+    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/RegeneratorPool.sol
+++ b/contracts/RegeneratorPool.sol
@@ -84,11 +84,11 @@ contract RegeneratorPool is Poolable, Blockable, Callable, ReentrancyGuard {
     // If no tokens are to be transferred, return.
     if (numTokens == 0) return;
 
+    regenerationCredit.decreaseLocked(numTokens);
+
     // Transfer the calculated tokens from this contract to the delegate.
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
-
-    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/ResearcherPool.sol
+++ b/contracts/ResearcherPool.sol
@@ -84,11 +84,11 @@ contract ResearcherPool is Poolable, Blockable, Callable, ReentrancyGuard {
     // If no tokens are to be transferred, return.
     if (numTokens == 0) return;
 
+    regenerationCredit.decreaseLocked(numTokens);
+
     // Transfer the calculated tokens from this contract to the delegate.
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
-
-    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/ResearcherPool.sol
+++ b/contracts/ResearcherPool.sol
@@ -88,7 +88,7 @@ contract ResearcherPool is Poolable, Blockable, Callable, ReentrancyGuard {
     bool success = regenerationCredit.transfer(delegate, numTokens);
     require(success, "ERC20: transfer failed");
 
-    regenerationCredit.decreaseLocked(address(this), numTokens);
+    regenerationCredit.decreaseLocked(numTokens);
   }
 
   /**

--- a/contracts/interfaces/IRegenerationCredit.sol
+++ b/contracts/interfaces/IRegenerationCredit.sol
@@ -14,7 +14,7 @@ interface IRegenerationCredit {
 
   function transferFrom(address owner, address to, uint256 numTokens) external returns (bool);
 
-  function decreaseLocked(address tokenOwner, uint256 numTokens) external;
+  function decreaseLocked(uint256 numTokens) external;
 
   /**
    * @notice Returns the total supply of tokens in existence.


### PR DESCRIPTION
PR to solve high risk findings from auditAgent tool related to the decreaseLocked function.

The parameter tokenOwner was removed, function is reading msg.sender directly and pool transfers calls are sending now only 1 parameter.

Also, the call to decreaseLocked was reorganized before the token transfer to avoid miscalculations of token balance. The unchecked was removed and a require to prevent underflow was added.

-----------------------------------

HighRisk description:

decreaseLocked is intended to be called by a pool to reflect the tokens it has just sent out:


function decreaseLocked(address tokenOwner, uint256 numTokens) external mustBeContractPool {
    require(numTokens <= balanceOf(tokenOwner), "Pool out of balance");
    if (contractsPools[tokenOwner]) totalLocked_ -= numTokens;
}
The mustBeContractPool modifier checks msg.sender, but the function updates totalLocked_ according to the tokenOwner parameter, which is not required to equal msg.sender.

Consequences:

Any address marked as a pool can call decreaseLocked passing a different pool in tokenOwner, reducing totalLocked_ even though the other pool has not transferred anything.
This silently breaks the invariant that totalLocked_ reflects the sum of pool balances and can later make honest transfers revert in RegenerationCredit.transfer because the internal accounting claims there are no locked tokens left.
The bug is a direct state-integrity violation and can be exploited by a single malicious pool to corrupt the bookkeeping of all others.


---------------------------------
High Risk 2:

Withdrawal logic can permanently brick every pool once >50% of its balance is withdrawn

High
All pool contracts first transfer the user’s reward and only afterwards call RegenerationCredit.decreaseLocked(...).


// e.g. ActivistPool.withdraw
bool success = regenerationCredit.transfer(delegate, numTokens);
require(success, "ERC20: transfer failed");

regenerationCredit.decreaseLocked(address(this), numTokens);   // <-- second call
decreaseLocked contains the following check:


require(numTokens <= balanceOf(tokenOwner), "Pool out of balance");
Because the tokens have already been sent out, balanceOf(address(this)) == previousBalance - numTokens. The require therefore becomes:

numTokens <= previousBalance - numTokens  ⇔  previousBalance >= 2 * numTokens
The call will revert as soon as a withdrawal tries to take more than half of the pool’s current balance (or whenever the pool’s remaining balance becomes smaller than the reward). From that moment on all subsequent withdrawals revert, freezing every remaining token in the pool and blocking rewards for all users.

No pool state is rolled back because the revert happens in a different contract (RegenerationCredit), so the pool’s accounting has already been updated and cannot be retried with a smaller amount, effectively bricking the whole pool.

---------------------

Unchecked subtraction in RegenerationCredit.decreaseLocked can lead to
totalLocked_ underflow
Medium Risk
The decreaseLocked function in RegenerationCredit.sol subtracts numTokens from the totalLocked_ state
variable within an unchecked block. The function's only validation is
require(numTokens <= balanceOf(tokenOwner)) . An attacker can artificially inflate a pool's balance by directly
transferring RC tokens to it, as pool contracts are standard addresses. When a legitimate withdrawal is triggered
from that pool, the balanceOf(tokenOwner) check will pass. However, the numTokens being withdrawn could be
larger than the totalLocked_ amount tracked by the protocol, causing totalLocked_ to underflow. This corrupts
a critical state variable used in _getEffectiveSupply to calculate the token's environmental impact backing,
undermining a core feature of the protocol.
// File: contracts/RegenerationCredit.sol
function decreaseLocked(address tokenOwner, uint256 numTokens) external mustBeContractPool {
 require(numTokens <= balanceOf(tokenOwner), "Pool out of balance");
 // Update total locked tokens.
 unchecked {
 if (contractsPools[tokenOwner]) totalLocked_ -= numTokens; // Vulnerable to underflow
 }
}