### PR TITLE
poolable precision factor

### DIFF
--- a/contracts/ActivistPool.sol
+++ b/contracts/ActivistPool.sol
@@ -75,8 +75,11 @@ contract ActivistPool is Poolable, Blockable, Callable, ReentrancyGuard {
   ) external mustBeAllowedCaller mustBeContractCall(activistRulesAddress) canWithdrawModifier(era) nonReentrant {
     require(era <= currentContractEra(), "Era in the future");
 
-    // Calculate the number of tokens the user is eligible to receive for the given era.
-    uint256 numTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+    // `highPrecisionTokens` is the value user is eligible to receive for the given era with 18 extra decimals of precision.
+    uint256 highPrecisionTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+
+    // Calculate the real number of tokens to transfer, scaling it back down.
+    uint256 numTokens = highPrecisionTokens / PRECISION_FACTOR;
 
     // Update the user's era and token balance state after the withdrawal.
     _updateEraAfterWithdraw(era, delegate, numTokens);

--- a/contracts/ContributorPool.sol
+++ b/contracts/ContributorPool.sol
@@ -75,8 +75,11 @@ contract ContributorPool is Poolable, Blockable, Callable, ReentrancyGuard {
   ) external mustBeAllowedCaller mustBeContractCall(contributorRulesAddress) canWithdrawModifier(era) nonReentrant {
     require(era <= currentContractEra(), "Era in the future");
 
-    // Calculate the number of tokens the user is eligible to receive for the given era.
-    uint256 numTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+    // `highPrecisionTokens` is the value user is eligible to receive for the given era with 18 extra decimals of precision.
+    uint256 highPrecisionTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+
+    // Calculate the real number of tokens to transfer, scaling it back down.
+    uint256 numTokens = highPrecisionTokens / PRECISION_FACTOR;
 
     // Update the user's era and token balance state after the withdrawal.
     _updateEraAfterWithdraw(era, delegate, numTokens);

--- a/contracts/DeveloperPool.sol
+++ b/contracts/DeveloperPool.sol
@@ -76,8 +76,11 @@ contract DeveloperPool is Poolable, Blockable, Callable, ReentrancyGuard {
   ) external mustBeAllowedCaller mustBeContractCall(developerRulesAddress) canWithdrawModifier(era) nonReentrant {
     require(era <= currentContractEra(), "Era in the future");
 
-    // Calculate the number of tokens the user is eligible to receive for the given era.
-    uint256 numTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+    // `highPrecisionTokens` is the value user is eligible to receive for the given era with 18 extra decimals of precision.
+    uint256 highPrecisionTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+
+    // Calculate the real number of tokens to transfer, scaling it back down.
+    uint256 numTokens = highPrecisionTokens / PRECISION_FACTOR;
 
     // Update the user's era and token balance state after the withdrawal.
     _updateEraAfterWithdraw(era, delegate, numTokens);

--- a/contracts/InspectorPool.sol
+++ b/contracts/InspectorPool.sol
@@ -75,8 +75,11 @@ contract InspectorPool is Poolable, Blockable, Callable, ReentrancyGuard {
   ) external mustBeAllowedCaller mustBeContractCall(inspectorRulesAddress) canWithdrawModifier(era) nonReentrant {
     require(era <= currentContractEra(), "Era in the future");
 
-    // Calculate the number of tokens the user is eligible to receive for the given era.
-    uint256 numTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+    // `highPrecisionTokens` is the value user is eligible to receive for the given era with 18 extra decimals of precision.
+    uint256 highPrecisionTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+
+    // Calculate the real number of tokens to transfer, scaling it back down.
+    uint256 numTokens = highPrecisionTokens / PRECISION_FACTOR;
 
     // Update the user's era and token balance state after the withdrawal.
     _updateEraAfterWithdraw(era, delegate, numTokens);

--- a/contracts/RegeneratorPool.sol
+++ b/contracts/RegeneratorPool.sol
@@ -75,8 +75,11 @@ contract RegeneratorPool is Poolable, Blockable, Callable, ReentrancyGuard {
   ) external mustBeAllowedCaller mustBeContractCall(regeneratorRulesAddress) canWithdrawModifier(era) nonReentrant {
     require(era <= currentContractEra(), "Era in the future");
 
-    // Calculate the number of tokens the user is eligible to receive for the given era.
-    uint256 numTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+    // `highPrecisionTokens` is the value user is eligible to receive for the given era with 18 extra decimals of precision.
+    uint256 highPrecisionTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+
+    // Calculate the real number of tokens to transfer, scaling it back down.
+    uint256 numTokens = highPrecisionTokens / PRECISION_FACTOR;
 
     // Update the user's era and token balance state after the withdrawal.
     _updateEraAfterWithdraw(era, delegate, numTokens);

--- a/contracts/ResearcherPool.sol
+++ b/contracts/ResearcherPool.sol
@@ -75,8 +75,11 @@ contract ResearcherPool is Poolable, Blockable, Callable, ReentrancyGuard {
   ) external mustBeAllowedCaller mustBeContractCall(researcherRulesAddress) canWithdrawModifier(era) nonReentrant {
     require(era <= currentContractEra(), "Era in the future");
 
-    // Calculate the number of tokens the user is eligible to receive for the given era.
-    uint256 numTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+    // `highPrecisionTokens` is the value user is eligible to receive for the given era with 18 extra decimals of precision.
+    uint256 highPrecisionTokens = _calculateUserEraTokens(era, delegate, tokensPerEra(getEpochForEra(era), halving));
+
+    // Calculate the real number of tokens to transfer, scaling it back down.
+    uint256 numTokens = highPrecisionTokens / PRECISION_FACTOR;
 
     // Update the user's era and token balance state after the withdrawal.
     _updateEraAfterWithdraw(era, delegate, numTokens);

--- a/contracts/shared/Poolable.sol
+++ b/contracts/shared/Poolable.sol
@@ -14,6 +14,9 @@ import { Era } from "contracts/types/PoolTypes.sol";
 contract Poolable {
   // --- State variables ---
 
+  /// @notice A scaling factor to preserve precision in reward calculations.
+  uint256 internal constant PRECISION_FACTOR = 10 ** 18;
+
   /// @notice The total supply of tokens to be managed by this contract.
   /// @dev This value is set once during contract deployment and remains constant.
   uint256 internal immutable totalTokens;
@@ -87,7 +90,7 @@ contract Poolable {
     // Return 0 if the user has no levels or there are no levels at all in the era to prevent division by zero.
     if (levelTo == 0 || levels == 0) return 0;
 
-    return (levelTo * _tokensPerEra) / levels;
+    return (levelTo * _tokensPerEra * PRECISION_FACTOR) / levels;
   }
 
   /**


### PR DESCRIPTION
Add poolable calculateUserEraTokens a precision factor to solve the audit issue:

Precision Loss in Token Distribution Calculation

Medium
In the _calculateUserEraTokens function of the Poolable contract, there is a calculation to determine the amount of tokens a user is eligible to receive based on their levels:


return (levelTo * _tokensPerEra) / levels;
This calculation performs division after multiplication, which is generally good for precision. However, there's still potential for precision loss due to the integer division. If (levelTo * _tokensPerEra) is not exactly divisible by levels, the result will be rounded down.

For example, if a user has 1 level out of 3 total levels, and there are 10 tokens to distribute, they should receive 3.33 tokens. However, the calculation will result in (1 * 10) / 3 = 3, meaning the user loses 0.33 tokens due to rounding.

This precision loss accumulates across all users and eras, potentially leading to a significant amount of tokens that are never distributed. The issue affects all pool contracts (ActivistPool, ContributorPool, DeveloperPool, InspectorPool, RegeneratorPool, ResearcherPool) and could result in users receiving fewer tokens than they should based on their contribution to the system.