### PR TITLE
Block denied inviter

### DIFF
--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -224,6 +224,7 @@ contract CommunityRules is Callable {
     require(userType != CommunityTypes.UserType.UNDEFINED, "Invalid user type"); // Must selected the appropriate userType
     require(_registrationProportionalityAllowed(userType), "Proportionality invalid"); // Vacancies according to the number of regenerators
     require(_invitedTypeOnRegister(addr, userType), "Invalid invitation"); // Only with valid invitation
+    require(!isDenied(invitations[addr].inviter), "Inviter denied"); // Inviter cannot be denied
 
     users[addr] = userType;
     usersCount++;

--- a/test/CommunityRules.test.js
+++ b/test/CommunityRules.test.js
@@ -27,6 +27,10 @@ describe("CommunityRules", function () {
     return await instance.connect(from).addDelation(denouncedAddress, "title", "testimony");
   };
 
+  const setToDenied = async (address, from) => {
+    return await instance.connect(from).setToDenied(address);
+  };
+
   beforeEach(async function () {
     [owner, user1Address, user2Address, user3Address, user4Address, user5Address, user6Address, user7Address] =
       await ethers.getSigners();
@@ -80,6 +84,20 @@ describe("CommunityRules", function () {
           await addUser(user1Address, userTypes.Regenerator, owner);
 
           await expect(addUser(user1Address, userTypes.Regenerator, owner)).to.be.revertedWith("User already exists");
+        });
+      });
+
+      context("when the inviter has been denied", () => {
+        beforeEach(async () => {
+          await addInvitation(owner, user2Address, userTypes.Activist, owner);
+          await addUser(user2Address, userTypes.Activist, owner);
+
+          await addInvitation(user2Address, user1Address, userTypes.Regenerator, owner);
+          await setToDenied(user2Address, owner);
+        });
+
+        it("should revert the addUser transaction for the invitee", async () => {
+          await expect(addUser(user1Address, userTypes.Regenerator, owner)).to.be.revertedWith("Inviter denied");
         });
       });
 


### PR DESCRIPTION
This PR adds a new require to the addUser function to block new registrations from denied inviters. After this change, if a user invites other wallets and gets denied, the inviters will not be able to register.