### PR TITLE
reorg _canVote/canInvite

### DIFF
--- a/contracts/VoteRules.sol
+++ b/contracts/VoteRules.sol
@@ -98,13 +98,13 @@ contract VoteRules {
    * @return bool True if the user meets the voting criteria, false otherwise.
    */
   function _canVoteRules(uint256 totalTypeLevels, uint256 totalUsers, uint256 userLevels) private pure returns (bool) {
-    // Rule 1: Allow anyone to vote if the user type has few members.
-    if (totalUsers <= INITIAL_USER_COUNT_THRESHOLD) return true;
-
     // Edge case: If there are no users, no one can vote.
     if (totalUsers == 0) {
       return false;
     }
+
+    // Rule 1: Allow anyone to vote if the user type has few members.
+    if (totalUsers <= INITIAL_USER_COUNT_THRESHOLD) return true;
 
     // Rule 2: Check if the user's level is strictly greater than the average
     return userLevels * totalUsers > totalTypeLevels;

--- a/contracts/shared/Invitable.sol
+++ b/contracts/shared/Invitable.sol
@@ -28,14 +28,14 @@ contract Invitable {
    * @return bool True if the user can invite, false otherwise.
    */
   function canInvite(uint256 totalLevels, uint256 totalUsers, uint256 userLevels) public pure returns (bool) {
-    // Rule 1: Allow anyone to invite if the system has few users.
-    if (totalUsers <= INITIAL_USER_COUNT_THRESHOLD) {
-      return true;
-    }
-
     // If there are no users, no one can invite. This also prevents totalUsers from being zero in the calculation.
     if (totalUsers == 0) {
       return false;
+    }
+
+    // Rule 1: Allow anyone to invite if the system has few users.
+    if (totalUsers <= INITIAL_USER_COUNT_THRESHOLD) {
+      return true;
     }
 
     // Rule 2: Check if the user's level is strictly greater than the average.


### PR DESCRIPTION
This PRs changes the order of the _canVoteRules to set the edge case before the rule 1 to check if is 0 before the rules. 