### PR TITLE
set cleanAverage

### DIFF
--- a/contracts/ActivistRules.sol
+++ b/contracts/ActivistRules.sol
@@ -237,7 +237,6 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
       regeneratorTotalInspections >= MINIMUM_INSPECTIONS_TO_WON_POOL_LEVELS
     ) {
       activistWonLevel[activistAddress][regeneratorAddress] = true;
-      approvedInvites++;
 
       bytes32 eventId = keccak256(abi.encodePacked("activist_reward_regenerator", activistAddress, regeneratorAddress));
 
@@ -264,7 +263,6 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
       inspectorTotalInspections >= MINIMUM_INSPECTIONS_TO_WON_POOL_LEVELS
     ) {
       activistWonLevel[activistAddress][inspectorAddress] = true;
-      approvedInvites++;
 
       bytes32 eventId = keccak256(abi.encodePacked("activist_reward_inspector", activistAddress, inspectorAddress));
 
@@ -283,6 +281,8 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
 
     // If activist does not exist, return.
     if (activist.id == 0) return;
+
+    approvedInvites++;
 
     // Increase totalActiveLevels.
     totalActiveLevels++;

--- a/contracts/ActivistRules.sol
+++ b/contracts/ActivistRules.sol
@@ -43,6 +43,9 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
   /// @notice The total count of all invitations that have been successfully approved across the entire system.
   uint64 public approvedInvites;
 
+  /// @notice The sum of all active levels from non-denied activists. Used for governance calculations.
+  uint256 public totalActiveLevels;
+
   /// @notice A mapping from an activist's wallet address to their detailed `Activist` data structure.
   /// This serves as the primary storage for activist profiles.
   mapping(address => Activist) private activists;
@@ -209,6 +212,7 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
   function removePoolLevels(
     address addr
   ) external mustBeAllowedCaller mustBeContractCall(validationRulesAddress) nonReentrant {
+    totalActiveLevels -= activists[addr].pool.level;
     activistPool.removePoolLevels(addr, true);
   }
 
@@ -280,6 +284,9 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
     // If activist does not exist, return.
     if (activist.id == 0) return;
 
+    // Increase totalActiveLevels.
+    totalActiveLevels++;
+
     // Inscrease the activist pool level
     activist.pool.level++;
 
@@ -306,7 +313,7 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
 
     // Calls the inherited `canInvite` function from `Invitable` to calculate eligibility.
     // This depends on total approved invites, total activist count, and the activist's pool level.
-    return canInvite(approvedInvites, communityRules.userTypesTotalCount(USER_TYPE), activist.pool.level);
+    return canInvite(totalActiveLevels, communityRules.userTypesCount(USER_TYPE), activist.pool.level);
   }
 
   /**

--- a/contracts/ActivistRules.sol
+++ b/contracts/ActivistRules.sol
@@ -284,7 +284,6 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
 
     approvedInvites++;
 
-    // Increase totalActiveLevels.
     totalActiveLevels++;
 
     // Inscrease the activist pool level

--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -266,7 +266,7 @@ contract CommunityRules is Callable {
    * @param userAddress The address of the user to be denied.
    */
   function setToDenied(address userAddress) external mustBeAllowedCaller {
-    if (users[userAddress] == CommunityTypes.UserType.UNDEFINED || deniedUsers[userAddress]) return;
+    if (deniedUsers[userAddress]) return;
 
     userTypesCount[users[userAddress]]--; // Decrement count of the old user type
 

--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -266,7 +266,7 @@ contract CommunityRules is Callable {
    * @param userAddress The address of the user to be denied.
    */
   function setToDenied(address userAddress) external mustBeAllowedCaller {
-    if (deniedUsers[userAddress]) return;
+    if (users[userAddress] == CommunityTypes.UserType.UNDEFINED || deniedUsers[userAddress]) return;
 
     userTypesCount[users[userAddress]]--; // Decrement count of the old user type
 

--- a/contracts/ContributorRules.sol
+++ b/contracts/ContributorRules.sol
@@ -60,6 +60,9 @@ contract ContributorRules is Callable, Invitable, ReentrancyGuard {
   /// This acts as a global unique ID counter for new contributions.
   uint64 public contributionsTotalCount;
 
+  /// @notice The sum of all active levels from valid contributions by non-denied contributors.
+  uint256 public totalActiveLevels;  
+
   /// @notice A mapping from a contributor's wallet address to their detailed `Contributor` data structure.
   /// This serves as the primary storage for contributor profiles.
   mapping(address => Contributor) private contributors;
@@ -226,6 +229,7 @@ contract ContributorRules is Callable, Invitable, ReentrancyGuard {
     // Increment global contribution counters and assign a unique ID.
     contributionsCount++;
     contributionsTotalCount++;
+    totalActiveLevels++;
     uint64 id = contributionsTotalCount;
 
     // Increment contributor's total contributions count within their struct.
@@ -377,6 +381,8 @@ contract ContributorRules is Callable, Invitable, ReentrancyGuard {
   function _denyContributor(address userAddress) private {
     if (communityRules.isDenied(userAddress)) return; // Already denied, nothing to do
 
+    totalActiveLevels -= contributors[userAddress].pool.level;
+
     communityRules.setToDenied(userAddress);
 
     // Inviter slashing mechanism.
@@ -420,6 +426,7 @@ contract ContributorRules is Callable, Invitable, ReentrancyGuard {
     contribution.invalidatedAt = block.number;
     contributions[contribution.id] = contribution;
     contributors[contribution.user].pool.level -= RESOURCE_LEVEL;
+    totalActiveLevels--;
 
     contributorPool.removePoolLevels(contribution.user, false);
   }
@@ -470,7 +477,7 @@ contract ContributorRules is Callable, Invitable, ReentrancyGuard {
 
     // Calls the inherited `canInvite` function from `Invitable` to calculate eligibility.
     // This depends on total contributions count, total contributor count, and the contributor's pool level.
-    return canInvite(contributionsTotalCount, communityRules.userTypesTotalCount(USER_TYPE), contributor.pool.level);
+    return canInvite(totalActiveLevels, communityRules.userTypesCount(USER_TYPE), contributor.pool.level);
   }
 
   /**

--- a/contracts/ContributorRules.sol
+++ b/contracts/ContributorRules.sol
@@ -61,7 +61,7 @@ contract ContributorRules is Callable, Invitable, ReentrancyGuard {
   uint64 public contributionsTotalCount;
 
   /// @notice The sum of all active levels from valid contributions by non-denied contributors.
-  uint256 public totalActiveLevels;  
+  uint256 public totalActiveLevels;
 
   /// @notice A mapping from a contributor's wallet address to their detailed `Contributor` data structure.
   /// This serves as the primary storage for contributor profiles.

--- a/contracts/DeveloperRules.sol
+++ b/contracts/DeveloperRules.sol
@@ -60,6 +60,9 @@ contract DeveloperRules is Callable, Invitable, ReentrancyGuard {
   /// This acts as a global unique ID counter for new reports.
   uint64 public reportsTotalCount;
 
+  /// @notice The sum of all active levels from valid reports by non-denied developers.
+  uint256 public totalActiveLevels;  
+
   /// @notice A mapping from a developer's wallet address to their detailed `Developer` data structure.
   /// This serves as the primary storage for developer profiles.
   mapping(address => Developer) private developers;
@@ -213,6 +216,7 @@ contract DeveloperRules is Callable, Invitable, ReentrancyGuard {
     // Increment global report counters and assign a unique ID.
     reportsCount++;
     reportsTotalCount++;
+    totalActiveLevels++;
     uint64 id = reportsTotalCount;
 
     // Increment developer's total reports count within their struct.
@@ -363,6 +367,7 @@ contract DeveloperRules is Callable, Invitable, ReentrancyGuard {
     report.invalidatedAt = block.number;
     reports[report.id] = report;
     developers[report.developer].pool.level -= RESOURCE_LEVEL;
+    totalActiveLevels--;
 
     developerPool.removePoolLevels(report.developer, false);
   }
@@ -373,6 +378,8 @@ contract DeveloperRules is Callable, Invitable, ReentrancyGuard {
    */
   function _denyDeveloper(address userAddress) private {
     if (communityRules.isDenied(userAddress)) return; // Already denied, nothing to do
+
+    totalActiveLevels -= developers[userAddress].pool.level;
 
     communityRules.setToDenied(userAddress);
 
@@ -419,7 +426,7 @@ contract DeveloperRules is Callable, Invitable, ReentrancyGuard {
 
     // Calls the inherited `canInvite` function from `Invitable` to calculate eligibility.
     // This depends on total reports count, total developer count, and the developer's pool level.
-    return canInvite(reportsTotalCount, communityRules.userTypesTotalCount(USER_TYPE), developer.pool.level);
+    return canInvite(totalActiveLevels, communityRules.userTypesCount(USER_TYPE), developer.pool.level);
   }
 
   /**

--- a/contracts/DeveloperRules.sol
+++ b/contracts/DeveloperRules.sol
@@ -61,7 +61,7 @@ contract DeveloperRules is Callable, Invitable, ReentrancyGuard {
   uint64 public reportsTotalCount;
 
   /// @notice The sum of all active levels from valid reports by non-denied developers.
-  uint256 public totalActiveLevels;  
+  uint256 public totalActiveLevels;
 
   /// @notice A mapping from a developer's wallet address to their detailed `Developer` data structure.
   /// This serves as the primary storage for developer profiles.

--- a/contracts/ResearcherRules.sol
+++ b/contracts/ResearcherRules.sol
@@ -74,6 +74,9 @@ contract ResearcherRules is Callable, Invitable, ReentrancyGuard {
   /// This acts as a global unique ID counter for new researchs.
   uint64 public researchesTotalCount;
 
+  /// @notice The sum of all active levels from valid researches by non-denied researchers.
+  uint256 public totalActiveLevels;  
+
   /// @notice Total calculatorItems count.
   uint64 public calculatorItemsCount;
 
@@ -230,6 +233,7 @@ contract ResearcherRules is Callable, Invitable, ReentrancyGuard {
 
     researchesCount++;
     researchesTotalCount++;
+    totalActiveLevels++;
     uint64 id = researchesTotalCount;
 
     researches[id] = Research(id, poolCurrentEra(), msg.sender, title, thesis, file, 0, true, 0, block.number);
@@ -413,6 +417,8 @@ contract ResearcherRules is Callable, Invitable, ReentrancyGuard {
   function _denyResearcher(address userAddress) private {
     if (communityRules.isDenied(userAddress)) return; // Already denied, nothing to do
 
+    totalActiveLevels -= researchers[userAddress].pool.level;
+
     communityRules.setToDenied(userAddress);
 
     // Inviter slashing mechanism.
@@ -436,6 +442,7 @@ contract ResearcherRules is Callable, Invitable, ReentrancyGuard {
     research.invalidatedAt = block.number;
     researches[research.id] = research;
     researchers[research.createdBy].pool.level -= RESOURCE_LEVEL;
+    totalActiveLevels--;
 
     researcherPool.removePoolLevels(research.createdBy, false);
   }

--- a/contracts/ResearcherRules.sol
+++ b/contracts/ResearcherRules.sol
@@ -75,7 +75,7 @@ contract ResearcherRules is Callable, Invitable, ReentrancyGuard {
   uint64 public researchesTotalCount;
 
   /// @notice The sum of all active levels from valid researches by non-denied researchers.
-  uint256 public totalActiveLevels;  
+  uint256 public totalActiveLevels;
 
   /// @notice Total calculatorItems count.
   uint64 public calculatorItemsCount;

--- a/contracts/ResearcherRules.sol
+++ b/contracts/ResearcherRules.sol
@@ -473,7 +473,7 @@ contract ResearcherRules is Callable, Invitable, ReentrancyGuard {
 
     if (researcher.id <= 0) return false;
 
-    return canInvite(researchesTotalCount, communityRules.userTypesTotalCount(USER_TYPE), researcher.pool.level);
+    return canInvite(totalActiveLevels, communityRules.userTypesCount(USER_TYPE), researcher.pool.level);
   }
 
   /**

--- a/contracts/VoteRules.sol
+++ b/contracts/VoteRules.sol
@@ -81,7 +81,7 @@ contract VoteRules {
     require(communityRules.isVoter(addr), "Not a voter user");
 
     CommunityTypes.UserType userType = communityRules.getUser(addr);
-    uint256 totalUsers = communityRules.userTypesTotalCount(userType);
+    uint256 totalUsers = communityRules.userTypesCount(userType);
 
     return _canVoteRules(_totalLevels(userType), totalUsers, _totalUserLevels(addr, userType));
   }
@@ -149,13 +149,13 @@ contract VoteRules {
    */
   function _totalLevels(CommunityTypes.UserType userType) private view returns (uint256) {
     if (userType == CommunityTypes.UserType.ACTIVIST) {
-      return activistRules.approvedInvites();
+      return activistRules.totalActiveLevels();
     } else if (userType == CommunityTypes.UserType.CONTRIBUTOR) {
-      return contributorRules.contributionsTotalCount();
+      return contributorRules.totalActiveLevels();
     } else if (userType == CommunityTypes.UserType.DEVELOPER) {
-      return developerRules.reportsTotalCount();
+      return developerRules.totalActiveLevels();
     } else if (userType == CommunityTypes.UserType.RESEARCHER) {
-      return researcherRules.researchesTotalCount();
+      return researcherRules.totalActiveLevels();
     } else {
       return 0;
     }

--- a/contracts/interfaces/IActivistRules.sol
+++ b/contracts/interfaces/IActivistRules.sol
@@ -64,5 +64,5 @@ interface IActivistRules {
    * @notice Returns the number of approved invites from non-denied users.
    * @return The total count of totalActiveLevels.
    */
-  function totalActiveLevels() external view returns (uint256);  
+  function totalActiveLevels() external view returns (uint256);
 }

--- a/contracts/interfaces/IActivistRules.sol
+++ b/contracts/interfaces/IActivistRules.sol
@@ -58,5 +58,11 @@ interface IActivistRules {
    * @dev This is likely a getter for a public state variable.
    * @return The total count of approved invites.
    */
-  function approvedInvites() external view returns (uint32);
+  function approvedInvites() external view returns (uint64);
+
+  /**
+   * @notice Returns the number of approved invites from non-denied users.
+   * @return The total count of totalActiveLevels.
+   */
+  function totalActiveLevels() external view returns (uint256);  
 }

--- a/contracts/interfaces/IActivistRules.sol
+++ b/contracts/interfaces/IActivistRules.sol
@@ -54,13 +54,6 @@ interface IActivistRules {
   function getActivist(address account) external view returns (Activist memory);
 
   /**
-   * @notice Returns the number of approved invites.
-   * @dev This is likely a getter for a public state variable.
-   * @return The total count of approved invites.
-   */
-  function approvedInvites() external view returns (uint64);
-
-  /**
    * @notice Returns the number of approved invites from non-denied users.
    * @return The total count of totalActiveLevels.
    */

--- a/contracts/interfaces/IContributorRules.sol
+++ b/contracts/interfaces/IContributorRules.sol
@@ -31,6 +31,12 @@ interface IContributorRules {
   function contributionsTotalCount() external view returns (uint64);
 
   /**
+   * @notice Returns the total number of activeLevels from non-denied users.
+   * @return The total count of totalActiveLevels.
+   */
+  function totalActiveLevels() external view returns (uint256);
+
+  /**
    * @notice Adds a penalty to a contributor and returns their new total penalty count.
    * @param contributor The address of the contributor receiving the penalty.
    * @param reportId The ID of the report related to the penalty.

--- a/contracts/interfaces/IContributorRules.sol
+++ b/contracts/interfaces/IContributorRules.sol
@@ -24,13 +24,6 @@ interface IContributorRules {
   function getContributor(address account) external view returns (Contributor memory);
 
   /**
-   * @notice Returns the total number of contributions made.
-   * @dev This is likely a getter for a public state variable.
-   * @return The total count of all contributions.
-   */
-  function contributionsTotalCount() external view returns (uint64);
-
-  /**
    * @notice Returns the total number of activeLevels from non-denied users.
    * @return The total count of totalActiveLevels.
    */

--- a/contracts/interfaces/IDeveloperRules.sol
+++ b/contracts/interfaces/IDeveloperRules.sol
@@ -31,6 +31,12 @@ interface IDeveloperRules {
   function reportsTotalCount() external view returns (uint64);
 
   /**
+   * @notice Returns the total number of activeLevels from non-denied users.
+   * @return The total count of totalActiveLevels.
+   */
+  function totalActiveLevels() external view returns (uint256);
+  
+  /**
    * @notice Adds a penalty to a developer and returns their new total penalty count.
    * @param developer The address of the developer receiving the penalty.
    * @param reportId The ID of the report related to the penalty.

--- a/contracts/interfaces/IDeveloperRules.sol
+++ b/contracts/interfaces/IDeveloperRules.sol
@@ -24,13 +24,6 @@ interface IDeveloperRules {
   function getDeveloper(address account) external view returns (Developer memory);
 
   /**
-   * @notice Returns the total number of reports made.
-   * @dev This is likely a getter for a public state variable.
-   * @return The total count of all reports.
-   */
-  function reportsTotalCount() external view returns (uint64);
-
-  /**
    * @notice Returns the total number of activeLevels from non-denied users.
    * @return The total count of totalActiveLevels.
    */

--- a/contracts/interfaces/IDeveloperRules.sol
+++ b/contracts/interfaces/IDeveloperRules.sol
@@ -35,7 +35,7 @@ interface IDeveloperRules {
    * @return The total count of totalActiveLevels.
    */
   function totalActiveLevels() external view returns (uint256);
-  
+
   /**
    * @notice Adds a penalty to a developer and returns their new total penalty count.
    * @param developer The address of the developer receiving the penalty.

--- a/contracts/interfaces/IResearcherRules.sol
+++ b/contracts/interfaces/IResearcherRules.sol
@@ -34,7 +34,7 @@ interface IResearcherRules {
    * @notice Returns the total number of activeLevels from non-denied users.
    * @return The total count of totalActiveLevels.
    */
-  function totalActiveLevels() external view returns (uint256);  
+  function totalActiveLevels() external view returns (uint256);
 
   /**
    * @notice Adds a penalty to a researcher and returns their new total penalty count.

--- a/contracts/interfaces/IResearcherRules.sol
+++ b/contracts/interfaces/IResearcherRules.sol
@@ -24,13 +24,6 @@ interface IResearcherRules {
   function getCalculatorItem(uint64 id) external view returns (CalculatorItem memory);
 
   /**
-   * @notice Returns the total number of researches made.
-   * @dev This is likely a getter for a public state variable.
-   * @return The total count of all researches.
-   */
-  function researchesTotalCount() external view returns (uint64);
-
-  /**
    * @notice Returns the total number of activeLevels from non-denied users.
    * @return The total count of totalActiveLevels.
    */

--- a/contracts/interfaces/IResearcherRules.sol
+++ b/contracts/interfaces/IResearcherRules.sol
@@ -31,6 +31,12 @@ interface IResearcherRules {
   function researchesTotalCount() external view returns (uint64);
 
   /**
+   * @notice Returns the total number of activeLevels from non-denied users.
+   * @return The total count of totalActiveLevels.
+   */
+  function totalActiveLevels() external view returns (uint256);  
+
+  /**
    * @notice Adds a penalty to a researcher and returns their new total penalty count.
    * @param researcher The address of the researcher receiving the penalty.
    * @param researchId The ID of the research item related to the penalty.

--- a/test/ActivistRules.test.js
+++ b/test/ActivistRules.test.js
@@ -14,6 +14,7 @@ describe("ActivistRules", () => {
     regenerator1Address,
     inspector1Address,
     inspector2Address,
+    inspector3Address,
     user1Address;
 
   const activistPoolArgs = {
@@ -31,8 +32,16 @@ describe("ActivistRules", () => {
   };
 
   beforeEach(async () => {
-    [owner, activ1Address, activ2Address, activ3Address, regenerator1Address, inspector1Address, inspector2Address] =
-      await ethers.getSigners();
+    [
+      owner,
+      activ1Address,
+      activ2Address,
+      activ3Address,
+      regenerator1Address,
+      inspector1Address,
+      inspector2Address,
+      inspector3Address,
+    ] = await ethers.getSigners();
 
     regenerationCredit = await regenerationCreditDeployed();
     communityRules = await communityRulesDeployed();
@@ -401,14 +410,20 @@ describe("ActivistRules", () => {
   describe("#removePoolLevels", () => {
     beforeEach(async () => {
       await addActivist("Activist  A", activ1Address);
+      await addActivist("Activist  B", activ3Address);
 
       await addInvitation(activ1Address, regenerator1Address, userTypes.Regenerator, owner);
       await addInvitation(activ1Address, inspector2Address, userTypes.Inspector, owner);
 
+      await addInvitation(activ3Address, inspector3Address, userTypes.Inspector, owner);
+
       await communityRules.addUser(regenerator1Address, userTypes.Regenerator, owner);
       await communityRules.addUser(inspector2Address, userTypes.Inspector, owner);
+      await communityRules.addUser(inspector3Address, userTypes.Inspector, owner);
+
       await instance.addRegeneratorLevel(regenerator1Address, 3);
       await instance.addInspectorLevel(inspector2Address, 3);
+      await instance.addInspectorLevel(inspector3Address, 3);
     });
 
     context("when user is denied", () => {
@@ -426,6 +441,12 @@ describe("ActivistRules", () => {
         const activist = await instance.getActivist(activ1Address);
 
         expect(activist.pool.level).to.equal(2);
+      });
+
+      it("remove all activist levels from totalActiveLevels", async () => {
+        const totalActiveLevels = await instance.totalActiveLevels();
+
+        expect(totalActiveLevels).to.equal(1);
       });
     });
   });

--- a/test/ContributorRules.test.js
+++ b/test/ContributorRules.test.js
@@ -294,6 +294,12 @@ describe("ContributorRules", (accounts) => {
             expect(contributionsCount).to.equal(1);
           });
 
+          it("increment totalActiveLevels", async () => {
+            const totalActiveLevels = await instance.totalActiveLevels();
+
+            expect(totalActiveLevels).to.equal(1);
+          });
+
           context("when adding contribution to eras", () => {
             beforeEach(async () => {
               await advanceBlock(contributorPoolParams.blocksPerEra);
@@ -595,6 +601,12 @@ describe("ContributorRules", (accounts) => {
             expect(contributionsCount).to.eq(0);
           });
 
+          it("must decrement totalActiveLevels in one", async () => {
+            const totalActiveLevels = await instance.totalActiveLevels();
+
+            expect(totalActiveLevels).to.eq(0);
+          });
+
           it("should set contributionPenalized to true to prevent double penalties", async () => {
             expect(await instance.contributionPenalized(1)).to.be.true;
           });
@@ -648,7 +660,11 @@ describe("ContributorRules", (accounts) => {
           await addDeveloper("User B", user2Address);
           await addDeveloper("User C", user3Address);
 
+          await addInvitation(owner, contr2Address, userTypes.Contributor, owner);
+          await addContributor("Contributor B", contr2Address);
+
           await addContribution(contr1Address);
+
           await instance.connect(user1Address).addContributionValidation(1, "justification");
           await instance.connect(user2Address).addContributionValidation(1, "justification");
 
@@ -666,6 +682,8 @@ describe("ContributorRules", (accounts) => {
           await advanceBlock(10);
 
           await addContribution(contr1Address);
+          await addContribution(contr2Address);
+
           await instance.connect(user1Address).addContributionValidation(3, "justification");
           await instance.connect(user2Address).addContributionValidation(3, "justification");
         });
@@ -694,6 +712,12 @@ describe("ContributorRules", (accounts) => {
           const contributor = await instance.getContributor(contr1Address);
 
           expect(contributor.pool.level).to.eq(1);
+        });
+
+        it("remove all contributor levels from totalActiveLevels", async () => {
+          const totalActiveLevels = await instance.totalActiveLevels();
+
+          expect(totalActiveLevels).to.equal(1);
         });
       });
 

--- a/test/DeveloperRules.test.js
+++ b/test/DeveloperRules.test.js
@@ -260,6 +260,12 @@ describe("DeveloperRules", (accounts) => {
           expect(reportsCount).to.equal(1);
         });
 
+        it("increment totalActiveLevels", async () => {
+          const totalActiveLevels = await instance.totalActiveLevels();
+
+          expect(totalActiveLevels).to.equal(1);
+        });
+
         it("add level to developer", async () => {
           const developer = await instance.getDeveloper(dev1Address);
 
@@ -446,6 +452,12 @@ describe("DeveloperRules", (accounts) => {
 
             expect(reportsCount).to.eq(0);
           });
+
+          it("decrement totalActiveLevels in one", async () => {
+            const totalActiveLevels = await instance.totalActiveLevels();
+
+            expect(totalActiveLevels).to.equal(0);
+          });
         });
 
         context("when report must not be invalidated", () => {
@@ -560,6 +572,12 @@ describe("DeveloperRules", (accounts) => {
           const developer = await instance.getDeveloper(user1Address);
 
           expect(developer.pool.level).to.eq(1);
+        });
+
+        it("remove all develeper levels from totalActiveLevels", async () => {
+          const totalActiveLevels = await instance.totalActiveLevels();
+
+          expect(totalActiveLevels).to.equal(16);
         });
       });
 

--- a/test/InvitationRules.test.js
+++ b/test/InvitationRules.test.js
@@ -25,7 +25,9 @@ describe("InvitationRules", () => {
     user5Address,
     user6Address,
     user7Address,
-    user8Address;
+    user8Address,
+    user9Address,
+    user10Address;
 
   const addUser = async (address, userType, from) => {
     await communityRules.connect(from).addUser(address, userType);
@@ -74,6 +76,8 @@ describe("InvitationRules", () => {
       user6Address,
       user7Address,
       user8Address,
+      user9Address,
+      user10Address,
       inspector1Address,
     ] = await ethers.getSigners();
 
@@ -154,9 +158,17 @@ describe("InvitationRules", () => {
           await addInvitation(user2Address, owner, userTypes.Activist, owner);
           await addInvitation(owner, user2Address, userTypes.Activist, owner);
           await addInvitation(owner, user3Address, userTypes.Activist, owner);
+          await addInvitation(owner, user6Address, userTypes.Activist, owner);
+          await addInvitation(owner, user7Address, userTypes.Activist, owner);
+          await addInvitation(owner, user8Address, userTypes.Activist, owner);
+          await addInvitation(owner, user9Address, userTypes.Activist, owner);
 
           await addActivist("Activist A", user2Address);
           await addActivist("Activist B", user3Address);
+          await addActivist("Activist C", user6Address);
+          await addActivist("Activist D", user7Address);
+          await addActivist("Activist E", user8Address);
+
           await communityRules.setContractCall(instance, owner);
         });
 
@@ -170,16 +182,74 @@ describe("InvitationRules", () => {
           });
 
           context("when send to activist", () => {
-            context("when have a previous invitation", () => {
-              context("when is not recent", () => {
+            context("when have less than 5 users", () => {
+              context("when have a previous invitation", () => {
+                context("when is not recent", () => {
+                  beforeEach(async () => {
+                    const blocks = await userTypeDelayBlocks(userTypes.Activist);
+
+                    await advanceBlock(blocks);
+                  });
+
+                  it("invite with success", async () => {
+                    await instance.connect(user2Address).invite(user4Address, userTypes.Activist);
+
+                    const invitation = await communityRules.invitations(user4Address);
+
+                    expect(invitation.invited).to.equal(user4Address.address);
+                  });
+                });
+
+                context("when is recent", () => {
+                  beforeEach(async () => {
+                    await instance.connect(user2Address).invite(user4Address, userTypes.Activist);
+                  });
+
+                  it("revert", async () => {
+                    await expect(
+                      instance.connect(user2Address).invite(user4Address, userTypes.Activist)
+                    ).to.be.revertedWith("Invite delay not reached");
+                  });
+                });
+              });
+
+              context("when do not have a previous invitation", () => {
+                it("invite with success", async () => {
+                  const invitation = await communityRules.invitations(user3Address);
+
+                  expect(invitation.invited).to.equal(user3Address.address);
+                });
+              });
+            });
+
+            context("when have more than 5 users", () => {
+              beforeEach(async () => {
+                await addActivist("Activist E", user9Address);
+
+                await addInvitation(user2Address, user4Address, userTypes.Inspector, owner);
+                await addInvitation(user2Address, user5Address, userTypes.Inspector, owner);
+
+                await communityRules.addUser(user4Address, userTypes.Inspector, owner);
+                await communityRules.addUser(user5Address, userTypes.Inspector, owner);
+
+                await activistRules.addRegeneratorLevel(user1Address, 3);
+
+                await activistRules.addInspectorLevel(user4Address, 3);
+                await activistRules.addInspectorLevel(user5Address, 3);
+                await activistRules.addInspectorLevel(inspector1Address, 3);
+              });
+
+              context("when is one of most active users", () => {
                 beforeEach(async () => {
                   const blocks = await userTypeDelayBlocks(userTypes.Activist);
 
                   await advanceBlock(blocks);
+
+                  await communityRules.setToDenied(user5Address);
                 });
 
                 it("invite with success", async () => {
-                  await instance.connect(user2Address).invite(user4Address, userTypes.Activist);
+                  await addInvitation(user2Address, user10Address, userTypes.Inspector, owner);
 
                   const invitation = await communityRules.invitations(user4Address);
 
@@ -187,24 +257,18 @@ describe("InvitationRules", () => {
                 });
               });
 
-              context("when is recent", () => {
+              context("when not is one of most active users", () => {
                 beforeEach(async () => {
-                  await instance.connect(user2Address).invite(user4Address, userTypes.Activist);
+                  const blocks = await userTypeDelayBlocks(userTypes.Activist);
+
+                  await advanceBlock(blocks);
                 });
 
-                it("revert", async () => {
+                it("returns error message", async () => {
                   await expect(
-                    instance.connect(user2Address).invite(user4Address, userTypes.Activist)
-                  ).to.be.revertedWith("Invite delay not reached");
+                    instance.connect(user3Address).invite(user10Address, userTypes.Activist)
+                  ).to.be.revertedWith("Only most active users allowed to invite");
                 });
-              });
-            });
-
-            context("when do not have a previous invitation", () => {
-              it("invite with success", async () => {
-                const invitation = await communityRules.invitations(user3Address);
-
-                expect(invitation.invited).to.equal(user3Address.address);
               });
             });
           });
@@ -309,14 +373,8 @@ describe("InvitationRules", () => {
         context("cannot send invite", () => {
           it("returns message error", async () => {
             await addInvitation(owner, user5Address, userTypes.Activist, owner);
-            await addInvitation(owner, user6Address, userTypes.Activist, owner);
-            await addInvitation(owner, user7Address, userTypes.Activist, owner);
-            await addInvitation(owner, user8Address, userTypes.Activist, owner);
 
             await addActivist("Activist C", user5Address);
-            await addActivist("Activist D", user6Address);
-            await addActivist("Activist E", user7Address);
-            await addActivist("Activist E", user8Address);
 
             await expect(instance.connect(user2Address).invite(user4Address, userTypes.Activist)).to.be.revertedWith(
               "Only most active users allowed to invite"
@@ -333,6 +391,7 @@ describe("InvitationRules", () => {
           await addInvitation(owner, user6Address, userTypes.Developer, owner);
           await addInvitation(owner, user7Address, userTypes.Developer, owner);
           await addInvitation(owner, user8Address, userTypes.Developer, owner);
+          await addInvitation(owner, user9Address, userTypes.Developer, owner);
 
           await addDeveloper("Developer A", user2Address);
           await addDeveloper("Developer B", user3Address);
@@ -347,12 +406,70 @@ describe("InvitationRules", () => {
           });
 
           context("when send to developer", () => {
-            context("when have a previous invitation", () => {
-              context("when is not recent", () => {
+            context("when have less than 5 users", () => {
+              context("when have a previous invitation", () => {
+                context("when is not recent", () => {
+                  beforeEach(async () => {
+                    const blocks = await userTypeDelayBlocks(userTypes.Developer);
+
+                    await advanceBlock(blocks);
+                  });
+
+                  it("invite with success", async () => {
+                    await instance.connect(user2Address).invite(user4Address, userTypes.Developer);
+
+                    const invitation = await communityRules.invitations(user4Address);
+
+                    expect(invitation.invited).to.equal(user4Address.address);
+                  });
+                });
+
+                context("when is recent", () => {
+                  beforeEach(async () => {
+                    await instance.connect(user2Address).invite(user4Address, userTypes.Developer);
+                  });
+
+                  it("revert", async () => {
+                    await expect(
+                      instance.connect(user2Address).invite(user4Address, userTypes.Developer)
+                    ).to.be.revertedWith("Invite delay not reached");
+                  });
+                });
+              });
+
+              context("when do not have a previous invitation", () => {
+                it("invite with success", async () => {
+                  await instance.connect(user2Address).invite(user4Address, userTypes.Developer);
+
+                  const invitation = await communityRules.invitations(user3Address);
+
+                  expect(invitation.invited).to.equal(user3Address.address);
+                });
+              });
+            });
+
+            context("when have more than 5 users", () => {
+              beforeEach(async () => {
+                await addDeveloper("Developer F", user9Address);
+
+                await developerRules.connect(user3Address).addReport("description", "report");
+
+                await developerRules.connect(user5Address).addReport("description", "report");
+                await advanceBlock(10);
+                await developerRules.connect(user5Address).addReport("description", "report");
+                await advanceBlock(10);
+                await developerRules.connect(user5Address).addReport("description", "report");
+                await advanceBlock(10);
+                await developerRules.connect(user5Address).addReport("description", "report");
+              });
+
+              context("when is one of most active users", () => {
                 beforeEach(async () => {
                   const blocks = await userTypeDelayBlocks(userTypes.Developer);
 
                   await advanceBlock(blocks);
+
+                  await communityRules.setToDenied(user5Address);
                 });
 
                 it("invite with success", async () => {
@@ -364,26 +481,18 @@ describe("InvitationRules", () => {
                 });
               });
 
-              context("when is recent", () => {
+              context("when not is one of most active users", () => {
                 beforeEach(async () => {
-                  await instance.connect(user2Address).invite(user4Address, userTypes.Developer);
+                  const blocks = await userTypeDelayBlocks(userTypes.Developer);
+
+                  await advanceBlock(blocks);
                 });
 
-                it("revert", async () => {
+                it("returns error message", async () => {
                   await expect(
                     instance.connect(user2Address).invite(user4Address, userTypes.Developer)
-                  ).to.be.revertedWith("Invite delay not reached");
+                  ).to.be.revertedWith("Only most active users allowed to invite");
                 });
-              });
-            });
-
-            context("when do not have a previous invitation", () => {
-              it("invite with success", async () => {
-                await instance.connect(user2Address).invite(user4Address, userTypes.Developer);
-
-                const invitation = await communityRules.invitations(user3Address);
-
-                expect(invitation.invited).to.equal(user3Address.address);
               });
             });
           });
@@ -408,6 +517,7 @@ describe("InvitationRules", () => {
           await addInvitation(owner, user6Address, userTypes.Contributor, owner);
           await addInvitation(owner, user7Address, userTypes.Contributor, owner);
           await addInvitation(owner, user8Address, userTypes.Contributor, owner);
+          await addInvitation(owner, user9Address, userTypes.Contributor, owner);
 
           await addContributor("Contributor A", user2Address);
           await addContributor("Contributor B", user3Address);
@@ -423,12 +533,70 @@ describe("InvitationRules", () => {
           });
 
           context("when send to contributor", () => {
-            context("when have a previous invitation", () => {
-              context("when is not recent", () => {
+            context("when have less than 5 users", () => {
+              context("when have a previous invitation", () => {
+                context("when is not recent", () => {
+                  beforeEach(async () => {
+                    const blocks = await userTypeDelayBlocks(userTypes.Contributor);
+
+                    await advanceBlock(blocks);
+                  });
+
+                  it("invite with success", async () => {
+                    await instance.connect(user2Address).invite(user4Address, userTypes.Contributor);
+
+                    const invitation = await communityRules.invitations(user4Address);
+
+                    expect(invitation.invited).to.equal(user4Address.address);
+                  });
+                });
+
+                context("when is recent", () => {
+                  beforeEach(async () => {
+                    await instance.connect(user2Address).invite(user4Address, userTypes.Contributor);
+                  });
+
+                  it("revert", async () => {
+                    await expect(
+                      instance.connect(user2Address).invite(user4Address, userTypes.Contributor)
+                    ).to.be.revertedWith("Invite delay not reached");
+                  });
+                });
+              });
+
+              context("when do not have a previous invitation", () => {
+                it("invite with success", async () => {
+                  await instance.connect(user2Address).invite(user4Address, userTypes.Contributor);
+
+                  const invitation = await communityRules.invitations(user3Address);
+
+                  expect(invitation.invited).to.equal(user3Address.address);
+                });
+              });
+            });
+
+            context("when have more than 5 users", () => {
+              beforeEach(async () => {
+                await addContributor("Contibutor F", user9Address);
+
+                await contributorRules.connect(user3Address).addContribution("description", "report");
+
+                await contributorRules.connect(user5Address).addContribution("description", "report");
+                await advanceBlock(10);
+                await contributorRules.connect(user5Address).addContribution("description", "report");
+                await advanceBlock(10);
+                await contributorRules.connect(user5Address).addContribution("description", "report");
+                await advanceBlock(10);
+                await contributorRules.connect(user5Address).addContribution("description", "report");
+              });
+
+              context("when is one of most active users", () => {
                 beforeEach(async () => {
                   const blocks = await userTypeDelayBlocks(userTypes.Contributor);
 
                   await advanceBlock(blocks);
+
+                  await communityRules.setToDenied(user5Address);
                 });
 
                 it("invite with success", async () => {
@@ -440,32 +608,24 @@ describe("InvitationRules", () => {
                 });
               });
 
-              context("when is recent", () => {
+              context("when not is one of most active users", () => {
                 beforeEach(async () => {
-                  await instance.connect(user2Address).invite(user4Address, userTypes.Contributor);
+                  const blocks = await userTypeDelayBlocks(userTypes.Contributor);
+
+                  await advanceBlock(blocks);
                 });
 
-                it("revert", async () => {
+                it("returns error message", async () => {
                   await expect(
                     instance.connect(user2Address).invite(user4Address, userTypes.Contributor)
-                  ).to.be.revertedWith("Invite delay not reached");
+                  ).to.be.revertedWith("Only most active users allowed to invite");
                 });
-              });
-            });
-
-            context("when do not have a previous invitation", () => {
-              it("invite with success", async () => {
-                await instance.connect(user2Address).invite(user4Address, userTypes.Contributor);
-
-                const invitation = await communityRules.invitations(user3Address);
-
-                expect(invitation.invited).to.equal(user3Address.address);
               });
             });
           });
         });
 
-        context("can not send invite", () => {
+        context("when can not send invite", () => {
           it("returns message error", async () => {
             await addContributor("Contributor F", user8Address);
 
@@ -484,6 +644,7 @@ describe("InvitationRules", () => {
           await addInvitation(owner, user6Address, userTypes.Researcher, owner);
           await addInvitation(owner, user7Address, userTypes.Researcher, owner);
           await addInvitation(owner, user8Address, userTypes.Researcher, owner);
+          await addInvitation(owner, user9Address, userTypes.Researcher, owner);
 
           await addResearcher("Researcher A", user2Address);
           await addResearcher("Researcher B", user3Address);
@@ -498,12 +659,70 @@ describe("InvitationRules", () => {
           });
 
           context("when send to researcher", () => {
-            context("when have a previous invitation", () => {
-              context("when is not recent", () => {
+            context("when have less than 5 users", () => {
+              context("when have a previous invitation", () => {
+                context("when is not recent", () => {
+                  beforeEach(async () => {
+                    const blocks = await userTypeDelayBlocks(userTypes.Researcher);
+
+                    await advanceBlock(blocks);
+                  });
+
+                  it("invite with success", async () => {
+                    await instance.connect(user2Address).invite(user4Address, userTypes.Researcher);
+
+                    const invitation = await communityRules.invitations(user4Address);
+
+                    expect(invitation.invited).to.equal(user4Address.address);
+                  });
+                });
+
+                context("when is recent", () => {
+                  beforeEach(async () => {
+                    await instance.connect(user2Address).invite(user4Address, userTypes.Researcher);
+                  });
+
+                  it("revert", async () => {
+                    await expect(
+                      instance.connect(user2Address).invite(user4Address, userTypes.Researcher)
+                    ).to.be.revertedWith("Invite delay not reached");
+                  });
+                });
+              });
+
+              context("when do not have a previous invitation", () => {
+                it("invite with success", async () => {
+                  await instance.connect(user2Address).invite(user4Address, userTypes.Researcher);
+
+                  const invitation = await communityRules.invitations(user4Address);
+
+                  expect(invitation.invited).to.equal(user4Address.address);
+                });
+              });
+            });
+
+            context("when have more than 5 users", () => {
+              beforeEach(async () => {
+                await addResearcher("Researcher F", user9Address);
+
+                await researcherRules.connect(user3Address).addResearch("description", "report", "file");
+
+                await researcherRules.connect(user5Address).addResearch("description", "report", "file");
+                await advanceBlock(10);
+                await researcherRules.connect(user5Address).addResearch("description", "report", "file");
+                await advanceBlock(10);
+                await researcherRules.connect(user5Address).addResearch("description", "report", "file");
+                await advanceBlock(10);
+                await researcherRules.connect(user5Address).addResearch("description", "report", "file");
+              });
+
+              context("when is one of most active users", () => {
                 beforeEach(async () => {
                   const blocks = await userTypeDelayBlocks(userTypes.Researcher);
 
                   await advanceBlock(blocks);
+
+                  await communityRules.setToDenied(user5Address);
                 });
 
                 it("invite with success", async () => {
@@ -515,26 +734,18 @@ describe("InvitationRules", () => {
                 });
               });
 
-              context("when is recent", () => {
+              context("when not is one of most active users", () => {
                 beforeEach(async () => {
-                  await instance.connect(user2Address).invite(user4Address, userTypes.Researcher);
+                  const blocks = await userTypeDelayBlocks(userTypes.Researcher);
+
+                  await advanceBlock(blocks);
                 });
 
-                it("revert", async () => {
+                it("returns error message", async () => {
                   await expect(
                     instance.connect(user2Address).invite(user4Address, userTypes.Researcher)
-                  ).to.be.revertedWith("Invite delay not reached");
+                  ).to.be.revertedWith("Only most active users allowed to invite");
                 });
-              });
-            });
-
-            context("when do not have a previous invitation", () => {
-              it("invite with success", async () => {
-                await instance.connect(user2Address).invite(user4Address, userTypes.Researcher);
-
-                const invitation = await communityRules.invitations(user4Address);
-
-                expect(invitation.invited).to.equal(user4Address.address);
               });
             });
           });

--- a/test/ResearcherRules.test.js
+++ b/test/ResearcherRules.test.js
@@ -329,6 +329,12 @@ describe("ResearcherRules", () => {
             expect(eraLevel).to.equal(0);
           });
 
+          it("increment totalActiveLevels", async () => {
+            const totalActiveLevels = await instance.totalActiveLevels();
+
+            expect(totalActiveLevels).to.equal(1);
+          });
+
           context("when is next era", () => {
             beforeEach(async () => {
               await advanceBlock(args.blocksPerEra);
@@ -432,7 +438,7 @@ describe("ResearcherRules", () => {
         await addResearcher("Researcher A", resea1Address);
       });
 
-      context("with valid contribution", () => {
+      context("with valid research", () => {
         context("when research must be invalidated", () => {
           beforeEach(async () => {
             await addResearch(resea1Address);
@@ -481,6 +487,12 @@ describe("ResearcherRules", () => {
             const researchesCount = await instance.researchesCount();
 
             expect(researchesCount).to.eq(0);
+          });
+
+          it("decrement totalActiveLevels in one", async () => {
+            const totalActiveLevels = await instance.totalActiveLevels();
+
+            expect(totalActiveLevels).to.equal(0);
           });
         });
 
@@ -545,6 +557,7 @@ describe("ResearcherRules", () => {
           await advanceBlock(10);
 
           await addResearch(resea1Address);
+          await addResearch(user2Address);
           await instance.connect(user1Address).addResearchValidation(3, "justification");
           await instance.connect(user2Address).addResearchValidation(3, "justification");
         });
@@ -559,6 +572,12 @@ describe("ResearcherRules", () => {
           const researcher = await instance.getResearcher(resea1Address);
 
           expect(researcher.pool.level).to.eq(1);
+        });
+
+        it("remove all develeper levels from totalActiveLevels", async () => {
+          const totalActiveLevels = await instance.totalActiveLevels();
+
+          expect(totalActiveLevels).to.equal(1);
         });
       });
 

--- a/test/VoteRules.test.js
+++ b/test/VoteRules.test.js
@@ -106,8 +106,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 4, totalUsers is 4 and userLevels is 1", () => {
           beforeEach(async () => {
-            await communityRules.mock.userTypesTotalCount.returns(4);
-            await activistRules.mock.approvedInvites.returns(4);
+            await communityRules.mock.userTypesCount.returns(4);
+            await activistRules.mock.totalActiveLevels.returns(4);
             await activistRules.mock.getActivist.returns(activistMockLevels(1));
           });
 
@@ -120,8 +120,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 10, totalUsers is 10 and userLevels is 1", () => {
           beforeEach(async () => {
-            await communityRules.mock.userTypesTotalCount.returns(10);
-            await activistRules.mock.approvedInvites.returns(10);
+            await communityRules.mock.userTypesCount.returns(10);
+            await activistRules.mock.totalActiveLevels.returns(10);
             await activistRules.mock.getActivist.returns(activistMockLevels(1));
           });
 
@@ -134,8 +134,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 60, totalUsers is 30 and userLevels is 1", () => {
           beforeEach(async () => {
-            await activistRules.mock.approvedInvites.returns(60);
-            await communityRules.mock.userTypesTotalCount.returns(30);
+            await activistRules.mock.totalActiveLevels.returns(60);
+            await communityRules.mock.userTypesCount.returns(30);
             await activistRules.mock.getActivist.returns(activistMockLevels(1));
           });
 
@@ -148,8 +148,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 60, totalUsers is 30 and userLevels is 3", () => {
           beforeEach(async () => {
-            await activistRules.mock.approvedInvites.returns(60);
-            await communityRules.mock.userTypesTotalCount.returns(30);
+            await activistRules.mock.totalActiveLevels.returns(60);
+            await communityRules.mock.userTypesCount.returns(30);
             await activistRules.mock.getActivist.returns(activistMockLevels(3));
           });
 
@@ -162,8 +162,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 6000, totalUsers is 600 and userLevels is 50", () => {
           beforeEach(async () => {
-            await activistRules.mock.approvedInvites.returns(6000);
-            await communityRules.mock.userTypesTotalCount.returns(600);
+            await activistRules.mock.totalActiveLevels.returns(6000);
+            await communityRules.mock.userTypesCount.returns(600);
             await activistRules.mock.getActivist.returns(activistMockLevels(50));
           });
 
@@ -176,8 +176,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 0, totalUsers is 10 and userLevels is 0", () => {
           beforeEach(async () => {
-            await activistRules.mock.approvedInvites.returns(0);
-            await communityRules.mock.userTypesTotalCount.returns(10);
+            await activistRules.mock.totalActiveLevels.returns(0);
+            await communityRules.mock.userTypesCount.returns(10);
             await activistRules.mock.getActivist.returns(activistMockLevels(0));
           });
 
@@ -190,8 +190,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 50000, totalUsers is 5000 and userLevels is 10", () => {
           beforeEach(async () => {
-            await activistRules.mock.approvedInvites.returns(50000);
-            await communityRules.mock.userTypesTotalCount.returns(5000);
+            await activistRules.mock.totalActiveLevels.returns(50000);
+            await communityRules.mock.userTypesCount.returns(5000);
             await activistRules.mock.getActivist.returns(activistMockLevels(10));
           });
 
@@ -204,8 +204,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 50000, totalUsers is 5000 and userLevels is 20", () => {
           beforeEach(async () => {
-            await activistRules.mock.approvedInvites.returns(50000);
-            await communityRules.mock.userTypesTotalCount.returns(5000);
+            await activistRules.mock.totalActiveLevels.returns(50000);
+            await communityRules.mock.userTypesCount.returns(5000);
             await activistRules.mock.getActivist.returns(activistMockLevels(20));
           });
 
@@ -224,8 +224,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 4, totalUsers is 4 and userLevels is 1", () => {
           beforeEach(async () => {
-            await contributorRules.mock.contributionsTotalCount.returns(4);
-            await communityRules.mock.userTypesTotalCount.returns(4);
+            await contributorRules.mock.totalActiveLevels.returns(4);
+            await communityRules.mock.userTypesCount.returns(4);
             await contributorRules.mock.getContributor.returns(contributorMockLevels(1));
           });
 
@@ -238,8 +238,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 10, totalUsers is 10 and userLevels is 1", () => {
           beforeEach(async () => {
-            await contributorRules.mock.contributionsTotalCount.returns(10);
-            await communityRules.mock.userTypesTotalCount.returns(10);
+            await contributorRules.mock.totalActiveLevels.returns(10);
+            await communityRules.mock.userTypesCount.returns(10);
             await contributorRules.mock.getContributor.returns(contributorMockLevels(1));
           });
 
@@ -252,8 +252,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 60, totalUsers is 30 and userLevels is 1", () => {
           beforeEach(async () => {
-            await contributorRules.mock.contributionsTotalCount.returns(60);
-            await communityRules.mock.userTypesTotalCount.returns(30);
+            await contributorRules.mock.totalActiveLevels.returns(60);
+            await communityRules.mock.userTypesCount.returns(30);
             await contributorRules.mock.getContributor.returns(contributorMockLevels(1));
           });
 
@@ -266,8 +266,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 60, totalUsers is 30 and userLevels is 3", () => {
           beforeEach(async () => {
-            await contributorRules.mock.contributionsTotalCount.returns(60);
-            await communityRules.mock.userTypesTotalCount.returns(30);
+            await contributorRules.mock.totalActiveLevels.returns(60);
+            await communityRules.mock.userTypesCount.returns(30);
             await contributorRules.mock.getContributor.returns(contributorMockLevels(3));
           });
 
@@ -280,8 +280,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 6000, totalUsers is 600 and userLevels is 50", () => {
           beforeEach(async () => {
-            await contributorRules.mock.contributionsTotalCount.returns(6000);
-            await communityRules.mock.userTypesTotalCount.returns(600);
+            await contributorRules.mock.totalActiveLevels.returns(6000);
+            await communityRules.mock.userTypesCount.returns(600);
             await contributorRules.mock.getContributor.returns(contributorMockLevels(50));
           });
 
@@ -294,8 +294,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 0, totalUsers is 10 and userLevels is 0", () => {
           beforeEach(async () => {
-            await contributorRules.mock.contributionsTotalCount.returns(0);
-            await communityRules.mock.userTypesTotalCount.returns(10);
+            await contributorRules.mock.totalActiveLevels.returns(0);
+            await communityRules.mock.userTypesCount.returns(10);
             await contributorRules.mock.getContributor.returns(contributorMockLevels(0));
           });
 
@@ -308,8 +308,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 50000, totalUsers is 5000 and userLevels is 10", () => {
           beforeEach(async () => {
-            await contributorRules.mock.contributionsTotalCount.returns(50000);
-            await communityRules.mock.userTypesTotalCount.returns(5000);
+            await contributorRules.mock.totalActiveLevels.returns(50000);
+            await communityRules.mock.userTypesCount.returns(5000);
             await contributorRules.mock.getContributor.returns(contributorMockLevels(10));
           });
 
@@ -322,8 +322,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 50000, totalUsers is 5000 and userLevels is 20", () => {
           beforeEach(async () => {
-            await contributorRules.mock.contributionsTotalCount.returns(50000);
-            await communityRules.mock.userTypesTotalCount.returns(5000);
+            await contributorRules.mock.totalActiveLevels.returns(50000);
+            await communityRules.mock.userTypesCount.returns(5000);
             await contributorRules.mock.getContributor.returns(contributorMockLevels(20));
           });
 
@@ -342,8 +342,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 4, totalUsers is 4 and userLevels is 1", () => {
           beforeEach(async () => {
-            await developerRules.mock.reportsTotalCount.returns(4);
-            await communityRules.mock.userTypesTotalCount.returns(4);
+            await developerRules.mock.totalActiveLevels.returns(4);
+            await communityRules.mock.userTypesCount.returns(4);
             await developerRules.mock.getDeveloper.returns(developerMockLevels(1));
           });
 
@@ -356,8 +356,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 10, totalUsers is 10 and userLevels is 1", () => {
           beforeEach(async () => {
-            await developerRules.mock.reportsTotalCount.returns(10);
-            await communityRules.mock.userTypesTotalCount.returns(10);
+            await developerRules.mock.totalActiveLevels.returns(10);
+            await communityRules.mock.userTypesCount.returns(10);
             await developerRules.mock.getDeveloper.returns(developerMockLevels(1));
           });
 
@@ -370,8 +370,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 60, totalUsers is 30 and userLevels is 1", () => {
           beforeEach(async () => {
-            await developerRules.mock.reportsTotalCount.returns(60);
-            await communityRules.mock.userTypesTotalCount.returns(30);
+            await developerRules.mock.totalActiveLevels.returns(60);
+            await communityRules.mock.userTypesCount.returns(30);
             await developerRules.mock.getDeveloper.returns(developerMockLevels(1));
           });
 
@@ -384,8 +384,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 60, totalUsers is 30 and userLevels is 3", () => {
           beforeEach(async () => {
-            await developerRules.mock.reportsTotalCount.returns(60);
-            await communityRules.mock.userTypesTotalCount.returns(30);
+            await developerRules.mock.totalActiveLevels.returns(60);
+            await communityRules.mock.userTypesCount.returns(30);
             await developerRules.mock.getDeveloper.returns(developerMockLevels(3));
           });
 
@@ -398,8 +398,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 6000, totalUsers is 600 and userLevels is 50", () => {
           beforeEach(async () => {
-            await developerRules.mock.reportsTotalCount.returns(6000);
-            await communityRules.mock.userTypesTotalCount.returns(600);
+            await developerRules.mock.totalActiveLevels.returns(6000);
+            await communityRules.mock.userTypesCount.returns(600);
             await developerRules.mock.getDeveloper.returns(developerMockLevels(50));
           });
 
@@ -412,8 +412,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 0, totalUsers is 10 and userLevels is 0", () => {
           beforeEach(async () => {
-            await developerRules.mock.reportsTotalCount.returns(0);
-            await communityRules.mock.userTypesTotalCount.returns(10);
+            await developerRules.mock.totalActiveLevels.returns(0);
+            await communityRules.mock.userTypesCount.returns(10);
             await developerRules.mock.getDeveloper.returns(developerMockLevels(0));
           });
 
@@ -426,8 +426,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 50000, totalUsers is 5000 and userLevels is 10", () => {
           beforeEach(async () => {
-            await developerRules.mock.reportsTotalCount.returns(50000);
-            await communityRules.mock.userTypesTotalCount.returns(5000);
+            await developerRules.mock.totalActiveLevels.returns(50000);
+            await communityRules.mock.userTypesCount.returns(5000);
             await developerRules.mock.getDeveloper.returns(developerMockLevels(10));
           });
 
@@ -440,8 +440,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 50000, totalUsers is 5000 and userLevels is 20", () => {
           beforeEach(async () => {
-            await developerRules.mock.reportsTotalCount.returns(50000);
-            await communityRules.mock.userTypesTotalCount.returns(5000);
+            await developerRules.mock.totalActiveLevels.returns(50000);
+            await communityRules.mock.userTypesCount.returns(5000);
             await developerRules.mock.getDeveloper.returns(developerMockLevels(20));
           });
 
@@ -460,8 +460,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 4, totalUsers is 4 and userLevels is 1", () => {
           beforeEach(async () => {
-            await researcherRules.mock.researchesTotalCount.returns(4);
-            await communityRules.mock.userTypesTotalCount.returns(4);
+            await researcherRules.mock.totalActiveLevels.returns(4);
+            await communityRules.mock.userTypesCount.returns(4);
             await researcherRules.mock.getResearcher.returns(researcherMockLevels(1));
           });
 
@@ -474,8 +474,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 10, totalUsers is 10 and userLevels is 1", () => {
           beforeEach(async () => {
-            await researcherRules.mock.researchesTotalCount.returns(10);
-            await communityRules.mock.userTypesTotalCount.returns(10);
+            await researcherRules.mock.totalActiveLevels.returns(10);
+            await communityRules.mock.userTypesCount.returns(10);
             await researcherRules.mock.getResearcher.returns(researcherMockLevels(1));
           });
 
@@ -488,8 +488,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 60, totalUsers is 30 and userLevels is 1", () => {
           beforeEach(async () => {
-            await researcherRules.mock.researchesTotalCount.returns(60);
-            await communityRules.mock.userTypesTotalCount.returns(30);
+            await researcherRules.mock.totalActiveLevels.returns(60);
+            await communityRules.mock.userTypesCount.returns(30);
             await researcherRules.mock.getResearcher.returns(researcherMockLevels(1));
           });
 
@@ -502,8 +502,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 60, totalUsers is 30 and userLevels is 3", () => {
           beforeEach(async () => {
-            await researcherRules.mock.researchesTotalCount.returns(60);
-            await communityRules.mock.userTypesTotalCount.returns(30);
+            await researcherRules.mock.totalActiveLevels.returns(60);
+            await communityRules.mock.userTypesCount.returns(30);
             await researcherRules.mock.getResearcher.returns(researcherMockLevels(3));
           });
 
@@ -516,8 +516,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 6000, totalUsers is 600 and userLevels is 50", () => {
           beforeEach(async () => {
-            await researcherRules.mock.researchesTotalCount.returns(6000);
-            await communityRules.mock.userTypesTotalCount.returns(600);
+            await researcherRules.mock.totalActiveLevels.returns(6000);
+            await communityRules.mock.userTypesCount.returns(600);
             await researcherRules.mock.getResearcher.returns(researcherMockLevels(50));
           });
 
@@ -530,8 +530,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 0, totalUsers is 10 and userLevels is 0", () => {
           beforeEach(async () => {
-            await researcherRules.mock.researchesTotalCount.returns(0);
-            await communityRules.mock.userTypesTotalCount.returns(10);
+            await researcherRules.mock.totalActiveLevels.returns(0);
+            await communityRules.mock.userTypesCount.returns(10);
             await researcherRules.mock.getResearcher.returns(researcherMockLevels(0));
           });
 
@@ -544,8 +544,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 50000, totalUsers is 5000 and userLevels is 10", () => {
           beforeEach(async () => {
-            await researcherRules.mock.researchesTotalCount.returns(50000);
-            await communityRules.mock.userTypesTotalCount.returns(5000);
+            await researcherRules.mock.totalActiveLevels.returns(50000);
+            await communityRules.mock.userTypesCount.returns(5000);
             await researcherRules.mock.getResearcher.returns(researcherMockLevels(10));
           });
 
@@ -558,8 +558,8 @@ describe("VoteRules", () => {
 
         context("when totalLevels is 50000, totalUsers is 5000 and userLevels is 20", () => {
           beforeEach(async () => {
-            await researcherRules.mock.researchesTotalCount.returns(50000);
-            await communityRules.mock.userTypesTotalCount.returns(5000);
+            await researcherRules.mock.totalActiveLevels.returns(50000);
+            await communityRules.mock.userTypesCount.returns(5000);
             await researcherRules.mock.getResearcher.returns(researcherMockLevels(20));
           });
 


### PR DESCRIPTION
PR to solve the issue that the canVote and canInvite functions were using the "dirty" average. This implementation changes the rule to use the clean average, counting only the non-denied levels and users to calculations.