### PR TITLE
limit to votesToInvalidate

### DIFF
--- a/contracts/ValidationRules.sol
+++ b/contracts/ValidationRules.sol
@@ -37,6 +37,7 @@ contract ValidationRules is Callable, ReentrancyGuard {
   /// @notice Votes thresholds to invalidate a resource/user.
   uint32 private constant VOTES_TO_INVALIDATE_LEVEL_1 = 2;
   uint32 private constant VOTES_TO_INVALIDATE_LEVEL_2 = 5;
+  uint32 private constant VOTES_TO_INVALIDATE_LEVEL_3 = 500;
 
   uint256 private constant DYNAMIC_INVALIDATION_PERCENTAGE = 3;
 
@@ -237,7 +238,7 @@ contract ValidationRules is Callable, ReentrancyGuard {
   /**
    * @notice Get how many validations is necessary to invalidate a user or resource.
    * @dev Calculates the required number of votes for invalidation based on the total number of registered voters in the system.
-   * Calculation is based on the `votersCount` which includes activists, researchers, developers, and contributors.
+   * Calculation is based on the `votersCount` which includes researchers, developers, and contributors.
    * @return count Number of votes required for invalidation.
    */
   function votesToInvalidate() public view returns (uint256) {
@@ -255,8 +256,14 @@ contract ValidationRules is Callable, ReentrancyGuard {
 
     // Threshold 3: Mature stage, calculates votes based on a percentage of active voters.
     uint256 invalidationVotes = (voters * DYNAMIC_INVALIDATION_PERCENTAGE) / 100;
+    uint256 requiredVotes = invalidationVotes + 1;
 
-    return invalidationVotes + 1;
+    // Threshold 4: Capped stage, returns a maximum votes level.
+    if (requiredVotes > VOTES_TO_INVALIDATE_LEVEL_3) {
+      return VOTES_TO_INVALIDATE_LEVEL_3;
+    }
+
+    return requiredVotes;
   }
 
   /**

--- a/test/ValidationRules.test.js
+++ b/test/ValidationRules.test.js
@@ -1190,15 +1190,27 @@ describe("ValidationRules", () => {
       });
     });
 
-    context("when votersCount is 20000", () => {
+    context("when votersCount is 15000", () => {
+      beforeEach(async () => {
+        await mockContract.mock.votersCount.returns(15000);
+      });
+
+      it("returns 451", async () => {
+        const votesToInvalidate = await instance.votesToInvalidate();
+
+        expect(votesToInvalidate).to.equal(451);
+      });
+    });
+
+    context("when votersCount is above limit", () => {
       beforeEach(async () => {
         await mockContract.mock.votersCount.returns(20000);
       });
 
-      it("returns 601", async () => {
+      it("returns 500", async () => {
         const votesToInvalidate = await instance.votesToInvalidate();
 
-        expect(votesToInvalidate).to.equal(601);
+        expect(votesToInvalidate).to.equal(500);
       });
     });
 
@@ -1207,22 +1219,22 @@ describe("ValidationRules", () => {
         await mockContract.mock.votersCount.returns(35000);
       });
 
-      it("returns 1051", async () => {
+      it("returns 500", async () => {
         const votesToInvalidate = await instance.votesToInvalidate();
 
-        expect(votesToInvalidate).to.equal(1051);
+        expect(votesToInvalidate).to.equal(500);
       });
     });
 
-    context("when votersCounts is 64000", () => {
+    context("when votersCounts is max", () => {
       beforeEach(async () => {
-        await mockContract.mock.votersCount.returns(64000);
+        await mockContract.mock.votersCount.returns(48000);
       });
 
-      it("returns 1921", async () => {
+      it("returns 500", async () => {
         const votesToInvalidate = await instance.votesToInvalidate();
 
-        expect(votesToInvalidate).to.equal(1921);
+        expect(votesToInvalidate).to.equal(500);
       });
     });
   });


### PR DESCRIPTION
Limit maximum votes to invalidate. The goal is to reverse the mechanism that difficulty for invalidation was only increasing with more resources/users and more votes to invalidate. Now the vote caps, creating a scenario were in the last 2/3 of the voters when new users come in the voters percentage reduces.