### PR TITLE
Fix impactRegenerators logic

### DIFF
--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -484,17 +484,17 @@ contract InspectionRules is Ownable, ReentrancyGuard {
    * @dev Sets the impact of a pending era to the global counter.
    */
   function _setEraImpact() private {
-    uint256 nexEraToSet = lastSettledEra + 1;
+    uint256 nextEraToSet = lastSettledEra + 1;
 
-    if (nexEraToSet < regeneratorRules.poolCurrentEra()) {
-      EraImpact storage eraImpact = impactPerEra[nexEraToSet];
+    if (nextEraToSet < regeneratorRules.poolCurrentEra()) {
+      EraImpact storage eraImpact = impactPerEra[nextEraToSet];
 
       inspectionsTreesImpact += eraImpact.trees;
       inspectionsBiodiversityImpact += eraImpact.biodiversity;
       realizedInspectionsCount += eraImpact.realizedInspections;
-      totalImpactRegenerators = regeneratorRules.onCertificationRegenerators();
+      totalImpactRegenerators += regeneratorRules.newCertificationRegenerators(nextEraToSet);
       // Update the lastSetlledEra to the era just settled.
-      lastSettledEra = nexEraToSet;
+      lastSettledEra = nextEraToSet;
     }
   }
 

--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -99,9 +99,9 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
   /// @notice The specific `UserType` enumeration value for a Regenerator user.
   CommunityTypes.UserType private constant USER_TYPE = CommunityTypes.UserType.REGENERATOR;
 
-  /// @notice The total count of regenerators that have started the certification process,
+  /// @notice The number of regenerators that have started the certification process on each era,
   /// and have reached the minimum of one inspection.
-  uint256 public onCertificationRegenerators;
+  mapping(uint256 => uint256) public newCertificationRegenerators;
 
   /// @notice The total count of regenerators who have completed the certification process,
   /// have reached the maximum allowed inspections.
@@ -330,7 +330,10 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
     require(totalInspections > 0, "totalInspections invalid");
 
     if (totalInspections == 1) {
-      onCertificationRegenerators--;
+      uint256 era = poolCurrentEra();
+      if (newCertificationRegenerators[era] > 0) {
+        newCertificationRegenerators[era]--;
+      }
       impactRegenerators[addr] = false;
     }
 
@@ -547,7 +550,8 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
     // Mark as impact regenerator.
     if (!impactRegenerators[addr]) {
       impactRegenerators[addr] = true;
-      onCertificationRegenerators++;
+      uint256 era = poolCurrentEra();
+      newCertificationRegenerators[era]++;
     }
 
     if (regenerator.totalInspections == MAXIMUM_INSPECTIONS) {

--- a/contracts/interfaces/IRegeneratorRules.sol
+++ b/contracts/interfaces/IRegeneratorRules.sol
@@ -67,10 +67,11 @@ interface IRegeneratorRules {
   function removePoolLevels(address user) external;
 
   /**
-   * @notice Returns the total number of ongoing certification regenerators, users with at least one inspection.
-   * @return The total of regenerators on the certification process.
+   * @notice Returns the number of new regenerators that achieved impact status in a specific era.
+   * @param era The era number to query.
+   * @return uint256 The count of new impact regenerators for that era.
    */
-  function onCertificationRegenerators() external view returns (uint256);
+  function newCertificationRegenerators(uint256 era) external view returns (uint256);
 
   /**
    * @notice Returns the total area under regeneration across all regenerators.

--- a/test/RegeneratorRules.test.js
+++ b/test/RegeneratorRules.test.js
@@ -397,7 +397,8 @@ describe("RegeneratorRules", () => {
       });
 
       it("should not add regenerator on certification process", async () => {
-        expect(await instance.onCertificationRegenerators()).to.equal(0);
+        const currentEra = await instance.poolCurrentEra();
+        expect(await instance.newCertificationRegenerators(currentEra)).to.equal(0);
       });
     });
 
@@ -562,15 +563,16 @@ describe("RegeneratorRules", () => {
         it("should correctly increment and then decrement counters", async () => {
           await instance.afterRealizeInspection(prod1Address, 1, 1);
 
+          const currentEra = await instance.poolCurrentEra();
           expect(await instance.impactRegenerators(prod1Address)).to.be.true;
-          expect(await instance.onCertificationRegenerators()).to.equal(1);
+          expect(await instance.newCertificationRegenerators(currentEra)).to.equal(1);
           let regenerator = await instance.getRegenerator(prod1Address);
           expect(regenerator.totalInspections).to.equal(1);
 
           await instance.decrementInspections(prod1Address);
 
           expect(await instance.impactRegenerators(prod1Address)).to.be.false;
-          expect(await instance.onCertificationRegenerators()).to.equal(0);
+          expect(await instance.newCertificationRegenerators(currentEra)).to.equal(0);
           regenerator = await instance.getRegenerator(prod1Address);
           expect(regenerator.totalInspections).to.equal(0);
         });


### PR DESCRIPTION
This PRs fix the problem due to the new past impact logic. It was necessary to register by era the on certification regenerators at a mapping.