### PR TITLE
13_set interfaces public

### DIFF
--- a/contracts/ActivistPool.sol
+++ b/contracts/ActivistPool.sol
@@ -20,7 +20,7 @@ contract ActivistPool is Poolable, Blockable, Callable, ReentrancyGuard {
   // --- Constants & state variables ---
 
   /// @notice Interface to the Regeneration Credit token contract, used to decrease total locked.
-  IRegenerationCredit private regenerationCredit;
+  IRegenerationCredit public regenerationCredit;
 
   /// @notice The total supply of Regeneration Credit tokens designated for this activist pool.
   /// This value represents the maximum tokens available for distribution through this contract.
@@ -30,7 +30,7 @@ contract ActivistPool is Poolable, Blockable, Callable, ReentrancyGuard {
   uint8 private constant RESOURCE_LEVEL = 1;
 
   /// @notice The address of the `ActivistRules` contract.
-  address private activistRulesAddress;
+  address public activistRulesAddress;
 
   /// @notice Tracks unique resource IDs to ensure levels for a resource are added only once.
   mapping(bytes32 => bool) public hasProcessedLevel;

--- a/contracts/ActivistRules.sol
+++ b/contracts/ActivistRules.sol
@@ -58,17 +58,17 @@ contract ActivistRules is Callable, Invitable, ReentrancyGuard {
 
   /// @notice The address of the `CommunityRules` contract, used to interact with
   /// community-wide rules, user types, and invitation data.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice The address of the `ActivistPool` contract, responsible for managing
   /// and distributing token rewards to activists.
-  IActivistPool private activistPool;
+  IActivistPool public activistPool;
 
   /// @notice The address of the `InspectionRules` contract.
-  address private inspectionRulesAddress;
+  address public inspectionRulesAddress;
 
   /// @notice The address of the `InspectionRules` contract.
-  address private validationRulesAddress;
+  address public validationRulesAddress;
 
   /// @notice The specific `UserType` enumeration value for the Activist user.
   CommunityTypes.UserType private constant USER_TYPE = CommunityTypes.UserType.ACTIVIST;

--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -75,10 +75,10 @@ contract CommunityRules is Callable {
   mapping(address => uint256) public lastDelationBlock;
 
   /// @notice The address of the `InvitationRules` contract.
-  address private invitationRulesAddress;
+  address public invitationRulesAddress;
 
   /// @notice The address of the `InvitationRules` contract.
-  address private validationRulesAddress;
+  address public validationRulesAddress;
 
   // --- Constructor ---
 

--- a/contracts/ContributorPool.sol
+++ b/contracts/ContributorPool.sol
@@ -20,7 +20,7 @@ contract ContributorPool is Poolable, Blockable, Callable, ReentrancyGuard {
   // --- Constants & state variables ---
 
   /// @notice Interface to the Regeneration Credit token contract, used for token transfers
-  IRegenerationCredit private regenerationCredit;
+  IRegenerationCredit public regenerationCredit;
 
   /// @notice The total supply of Regeneration Credit tokens designated for this contributor pool.
   /// This value represents the maximum tokens available for distribution through this contract.
@@ -30,7 +30,7 @@ contract ContributorPool is Poolable, Blockable, Callable, ReentrancyGuard {
   uint8 private constant RESOURCE_LEVEL = 1;
 
   /// @notice The address of the `ContributorRules` contract.
-  address private contributorRulesAddress;
+  address public contributorRulesAddress;
 
   /// @notice Tracks unique resource IDs to ensure levels for a resource are added only once.
   mapping(uint64 => bool) public hasProcessedLevel;

--- a/contracts/ContributorRules.sol
+++ b/contracts/ContributorRules.sol
@@ -80,22 +80,22 @@ contract ContributorRules is Callable, Invitable, ReentrancyGuard {
 
   /// @notice The interface of the `CommunityRules` contract, used to interact with
   /// community-wide rules, user types, and invitation data.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice The interface of the `ContributorPool` contract, responsible for managing
   /// and distributing token rewards to contributors.
-  IContributorPool private contributorPool;
+  IContributorPool public contributorPool;
 
   /// @notice The interface of the `ValidationRules` contract, which defines the rules
   /// and processes for validating or invalidating contributions.
-  IValidationRules private validationRules;
+  IValidationRules public validationRules;
 
   /// @notice The interface of the `VoteRules` contract, which defines rules for user voting
   /// eligibility, particularly for contribution validation.
-  IVoteRules private voteRules;
+  IVoteRules public voteRules;
 
   /// @notice The address of the `InspectionRules` contract.
-  address private validationRulesAddress;
+  address public validationRulesAddress;
 
   /// @notice The specific `UserType` enumeration value for a Contributor user.
   CommunityTypes.UserType private constant USER_TYPE = CommunityTypes.UserType.CONTRIBUTOR;

--- a/contracts/DeveloperPool.sol
+++ b/contracts/DeveloperPool.sol
@@ -21,7 +21,7 @@ contract DeveloperPool is Poolable, Blockable, Callable, ReentrancyGuard {
   // --- Constants & state variables ---
 
   /// @notice Interface to the Regeneration Credit token contract, used to decrease total locked.
-  IRegenerationCredit private regenerationCredit;
+  IRegenerationCredit public regenerationCredit;
 
   /// @notice The total supply of Regeneration Credit tokens designated for this developer pool.
   /// This value represents the maximum tokens available for distribution through this contract.
@@ -31,7 +31,7 @@ contract DeveloperPool is Poolable, Blockable, Callable, ReentrancyGuard {
   uint8 private constant RESOURCE_LEVEL = 1;
 
   /// @notice The address of the `DeveloperRules` contract.
-  address private developerRulesAddress;
+  address public developerRulesAddress;
 
   /// @notice Tracks unique resource IDs to ensure levels for a resource are added only once.
   mapping(uint64 => bool) public hasProcessedLevel;

--- a/contracts/DeveloperRules.sol
+++ b/contracts/DeveloperRules.sol
@@ -83,22 +83,22 @@ contract DeveloperRules is Callable, Invitable, ReentrancyGuard {
 
   /// @notice The interface of the `CommunityRules` contract, used to interact with
   /// community-wide rules, user types, and invitation data.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice The interface of the `DeveloperPool` contract, responsible for managing
   /// and distributing token rewards to developers.
-  IDeveloperPool private developerPool;
+  IDeveloperPool public developerPool;
 
   /// @notice The interface of the `ValidationRules` contract, which defines the rules
   /// and processes for validating or invalidating development reports.
-  IValidationRules private validationRules;
+  IValidationRules public validationRules;
 
   /// @notice The interface of the `VoteRules` contract, which defines rules for user voting
   /// eligibility, particularly for report validation.
-  IVoteRules private voteRules;
+  IVoteRules public voteRules;
 
   /// @notice The address of the `InspectionRules` contract.
-  address private validationRulesAddress;
+  address public validationRulesAddress;
 
   /// @notice The specific `UserType` enumeration value for a Developer user.
   CommunityTypes.UserType private constant USER_TYPE = CommunityTypes.UserType.DEVELOPER;

--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -88,25 +88,25 @@ contract InspectionRules is Ownable, ReentrancyGuard {
   mapping(address => mapping(address => bool)) private inspectorInspected;
 
   /// @notice InspectorRules contract interface for interacting with inspector-specific logic.
-  IInspectorRules private inspectorRules;
+  IInspectorRules public inspectorRules;
 
   /// @notice RegeneratorRules contract interface for interacting with regenerator-specific logic.
-  IRegeneratorRules private regeneratorRules;
+  IRegeneratorRules public regeneratorRules;
 
   /// @notice CommunityRules contract interface for checking user types and other community-wide rules.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice ValidationRules contract interface for handling inspection invalidations.
-  IValidationRules private validationRules;
+  IValidationRules public validationRules;
 
   /// @notice ActivistRules contract interface for updating activist levels based on inspection activities.
-  IActivistRules private activistRules;
+  IActivistRules public activistRules;
 
   /// @notice VoteRules contract interface for checking voter eligibility.
-  IVoteRules private voteRules;
+  IVoteRules public voteRules;
 
   /// @notice RegenerationIndexRules contract interface for calculating regeneration scores.
-  IRegenerationIndexRules private regenerationIndexRules;
+  IRegenerationIndexRules public regenerationIndexRules;
 
   /// @notice Tracks which validator has voted on which inspection to prevent duplicate votes.
   mapping(address => mapping(uint256 => bool)) private validatorInspectionsValidations;

--- a/contracts/InspectorPool.sol
+++ b/contracts/InspectorPool.sol
@@ -20,7 +20,7 @@ contract InspectorPool is Poolable, Blockable, Callable, ReentrancyGuard {
   // --- Constants & state variables ---
 
   /// @notice Interface to the Regeneration Credit token contract, used to decrease total locked.
-  IRegenerationCredit private regenerationCredit;
+  IRegenerationCredit public regenerationCredit;
 
   /// @notice The total supply of Regeneration Credit tokens designated for this inspector pool.
   /// This value represents the maximum tokens available for distribution through this contract.
@@ -30,7 +30,7 @@ contract InspectorPool is Poolable, Blockable, Callable, ReentrancyGuard {
   uint8 private constant RESOURCE_LEVEL = 1;
 
   /// @notice The address of the `InspectorRules` contract.
-  address private inspectorRulesAddress;
+  address public inspectorRulesAddress;
 
   /// @notice Tracks unique resource IDs to ensure levels for a resource are added only once.
   mapping(uint64 => bool) public hasProcessedLevel;

--- a/contracts/InspectorRules.sol
+++ b/contracts/InspectorRules.sol
@@ -57,14 +57,14 @@ contract InspectorRules is Callable, ReentrancyGuard {
 
   /// @notice The address of the `CommunityRules` contract, used to interact with
   /// community-wide rules and user types.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice The address of the `InspectorPool` contract, responsible for managing
   /// and distributing token rewards to inspectors.
-  IInspectorPool private inspectorPool;
+  IInspectorPool public inspectorPool;
 
   /// @notice The address of the `InspectionRules` contract.
-  address private inspectionRulesAddress;
+  address public inspectionRulesAddress;
 
   /// @notice The specific `UserType` enumeration value for an Inspector user.
   /// This is a constant for gas efficiency and clarity.

--- a/contracts/InvitationRules.sol
+++ b/contracts/InvitationRules.sol
@@ -41,19 +41,19 @@ contract InvitationRules is Ownable, ReentrancyGuard {
   mapping(CommunityTypes.UserType => CommunityTypes.UserType) public canBeInviteds;
 
   /// @notice CommunityRules contract interface
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice ResearcherRules contract interface
-  IResearcherRules private researcherRules;
+  IResearcherRules public researcherRules;
 
   /// @notice DeveloperRules contract interface
-  IDeveloperRules private developerRules;
+  IDeveloperRules public developerRules;
 
   /// @notice ActivistRules contract interface
-  IActivistRules private activistRules;
+  IActivistRules public activistRules;
 
   /// @notice ContributorRules contract interface
-  IContributorRules private contributorRules;
+  IContributorRules public contributorRules;
 
   // --- Constructor ---
 

--- a/contracts/RegenerationCreditImpact.sol
+++ b/contracts/RegenerationCreditImpact.sol
@@ -32,13 +32,13 @@ contract RegenerationCreditImpact {
   // --- State variables ---
 
   /// @notice Interface to the `RegenerationCredit` contract.
-  IRegenerationCredit private regenerationCredit;
+  IRegenerationCredit public regenerationCredit;
 
   /// @notice Interface to the `InspectionRules` contract.
-  IInspectionRules private inspectionRules;
+  IInspectionRules public inspectionRules;
 
   /// @notice Interface to the `RegeneratorRules` contract.
-  IRegeneratorRules private regeneratorRules;
+  IRegeneratorRules public regeneratorRules;
 
   // --- Constructor ---
 

--- a/contracts/RegeneratorPool.sol
+++ b/contracts/RegeneratorPool.sol
@@ -20,14 +20,14 @@ contract RegeneratorPool is Poolable, Blockable, Callable, ReentrancyGuard {
   // --- Constants & state variables ---
 
   /// @notice Interface to the Regeneration Credit token contract, used to decrease total locked.
-  IRegenerationCredit private regenerationCredit;
+  IRegenerationCredit public regenerationCredit;
 
   /// @notice The total supply of Regeneration Credit tokens designated for this regenerator pool.
   /// This value represents the maximum tokens available for distribution through this contract.
   uint256 private constant TOTAL_POOL_TOKENS = 750000000e18;
 
   /// @notice The address of the `RegeneratorRules` contract.
-  address private regeneratorRulesAddress;
+  address public regeneratorRulesAddress;
 
   /// @notice Maximum possible score from a single resource.
   uint256 public constant MAX_NEW_LEVELS = 192;

--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -82,11 +82,11 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
 
   /// @notice The address of the `CommunityRules` contract, used to interact with
   /// community-wide rules and user types.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice The address of the `RegeneratorPool` contract, responsible for managing
   /// and distributing token rewards to regenerators.
-  IRegeneratorPool private regeneratorPool;
+  IRegeneratorPool public regeneratorPool;
 
   /// @notice The specific `UserType` enumeration value for a Regenerator user.
   CommunityTypes.UserType private constant USER_TYPE = CommunityTypes.UserType.REGENERATOR;
@@ -100,10 +100,10 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
   uint256 public regenerationArea;
 
   /// @notice The address of the `InspectionRules` contract.
-  address private inspectionRulesAddress;
+  address public inspectionRulesAddress;
 
   /// @notice The address of the `InspectionRules` contract.
-  address private validationRulesAddress;
+  address public validationRulesAddress;
 
   // --- Constructor ---
 

--- a/contracts/ResearcherPool.sol
+++ b/contracts/ResearcherPool.sol
@@ -20,7 +20,7 @@ contract ResearcherPool is Poolable, Blockable, Callable, ReentrancyGuard {
   // --- Constants & state variables ---
 
   /// @notice Interface to the Regeneration Credit token contract, used to decrease total locked.
-  IRegenerationCredit private regenerationCredit;
+  IRegenerationCredit public regenerationCredit;
 
   /// @notice The total supply of Regeneration Credit tokens designated for this researcher pool.
   /// This value represents the maximum tokens available for distribution through this contract.
@@ -30,7 +30,7 @@ contract ResearcherPool is Poolable, Blockable, Callable, ReentrancyGuard {
   uint8 private constant RESOURCE_LEVEL = 1;
 
   /// @notice The address of the `ResearcherRules` contract.
-  address private researcherRulesAddress;
+  address public researcherRulesAddress;
 
   /// @notice Tracks unique resource IDs to ensure levels for a resource are added only once.
   mapping(uint64 => bool) public hasProcessedLevel;

--- a/contracts/ResearcherRules.sol
+++ b/contracts/ResearcherRules.sol
@@ -109,19 +109,19 @@ contract ResearcherRules is Callable, Invitable, ReentrancyGuard {
 
   /// @notice The interface of the `CommunityRules` contract, used to interact with
   /// community-wide rules, user types, and invitation data.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice The interface of the `ResearcherPool` contract, responsible for managing
   /// and distributing token rewards to researchers.
-  IResearcherPool private researcherPool;
+  IResearcherPool public researcherPool;
 
   /// @notice The interface of the `ValidationRules` contract, which defines the rules
   /// and processes for validating or invalidating development reports.
-  IValidationRules private validationRules;
+  IValidationRules public validationRules;
 
   /// @notice The interface of the `VoteRules` contract, which defines rules for user voting
   /// eligibility, particularly for report validation.
-  IVoteRules private voteRules;
+  IVoteRules public voteRules;
 
   /// @notice The specific `UserType` enumeration value for a Researcher user.
   CommunityTypes.UserType private constant USER_TYPE = CommunityTypes.UserType.RESEARCHER;

--- a/contracts/SupporterRules.sol
+++ b/contracts/SupporterRules.sol
@@ -64,10 +64,10 @@ contract SupporterRules is ReentrancyGuard {
   mapping(uint64 => Offset) public offsets;
 
   /// @notice CommunityRules contract interface.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice ResearcherRules contract interface.
-  IResearcherRules private researcherRules;
+  IResearcherRules public researcherRules;
 
   IRegenerationCredit public regenerationCredit;
 

--- a/contracts/ValidationRules.sol
+++ b/contracts/ValidationRules.sol
@@ -52,28 +52,28 @@ contract ValidationRules is Callable, ReentrancyGuard {
   mapping(address => uint256) public validatorLastVoteAt;
 
   /// @notice CommunityRules contract interface.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice RegeneratorRules contract interface.
-  IRegeneratorRules private regeneratorRules;
+  IRegeneratorRules public regeneratorRules;
 
   /// @notice InspectorRules contract interface.
-  IInspectorRules private inspectorRules;
+  IInspectorRules public inspectorRules;
 
   /// @notice DeveloperRules contract interface.
-  IDeveloperRules private developerRules;
+  IDeveloperRules public developerRules;
 
   /// @notice ResearcherRules contract interface.
-  IResearcherRules private researcherRules;
+  IResearcherRules public researcherRules;
 
   /// @notice ContributorRules contract interface.
-  IContributorRules private contributorRules;
+  IContributorRules public contributorRules;
 
   /// @notice ActivistRules contract interface.
-  IActivistRules private activistRules;
+  IActivistRules public activistRules;
 
   /// @notice VoteRules contract interface.
-  IVoteRules private voteRules;
+  IVoteRules public voteRules;
 
   /// @notice Amount of blocks between votes.
   uint256 public immutable timeBetweenVotes;

--- a/contracts/VoteRules.sol
+++ b/contracts/VoteRules.sol
@@ -30,19 +30,19 @@ contract VoteRules {
   // --- State variables ---
 
   /// @notice CommunityRules contract interface.
-  ICommunityRules private communityRules;
+  ICommunityRules public communityRules;
 
   /// @notice ActivistRules contract interface.
-  IActivistRules private activistRules;
+  IActivistRules public activistRules;
 
   /// @notice ContributorRules contract interface.
-  IContributorRules private contributorRules;
+  IContributorRules public contributorRules;
 
   /// @notice DeveloperRules contract interface.
-  IDeveloperRules private developerRules;
+  IDeveloperRules public developerRules;
 
   /// @notice ResearcherRules contract interface.
-  IResearcherRules private researcherRules;
+  IResearcherRules public researcherRules;
 
   // --- Constructor ---
 


### PR DESCRIPTION
PR to reduce the risk of issue 13 pointed at the audit.

This problem will be mitigated with a manual review of the contracts settings and balance after mainnet deploy. The same applies to other configurations such as allowedCallers and calls interfaces. For the review, it was missing to set the interfaces public so it can be easily checked.