### PR TITLE
11_inspectors_giveUps

### DIFF
--- a/contracts/InspectorRules.sol
+++ b/contracts/InspectorRules.sol
@@ -388,7 +388,7 @@ contract InspectorRules is Callable, ReentrancyGuard {
    * @return bool `true` if the inspector is currently valid (has less than max give-ups), `false` otherwise.
    */
   function isInspectorValid(address addr) public view returns (bool) {
-    return inspectors[addr].giveUps < MAX_GIVEUPS;
+    return inspectors[addr].giveUps <= MAX_GIVEUPS;
   }
 
   /**

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -21,6 +21,7 @@ describe("InspectionRules", () => {
     regenerator2Address,
     regenerator3Address,
     regenerator4Address,
+    regenerator5Address,
     inspectorAddress,
     inspector2Address,
     inspector3Address,
@@ -153,6 +154,7 @@ describe("InspectionRules", () => {
       regenerator2Address,
       regenerator3Address,
       regenerator4Address,
+      regenerator5Address,
       inspectorAddress,
       inspector2Address,
       inspector3Address,
@@ -564,10 +566,12 @@ describe("InspectionRules", () => {
             await addInvitation(owner, regenerator2Address, userTypes.Regenerator, owner);
             await addInvitation(owner, regenerator3Address, userTypes.Regenerator, owner);
             await addInvitation(owner, regenerator4Address, userTypes.Regenerator, owner);
+            await addInvitation(owner, regenerator5Address, userTypes.Regenerator, owner);
 
             await addRegenerator("Regenerator B", 25000, regenerator2Address);
             await addRegenerator("Regenerator C", 25000, regenerator3Address);
             await addRegenerator("Regenerator D", 25000, regenerator4Address);
+            await addRegenerator("Regenerator E", 25000, regenerator5Address);
 
             await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
             await acceptInspection(1, inspectorAddress);
@@ -585,10 +589,15 @@ describe("InspectionRules", () => {
 
             await requestInspection(regenerator4Address);
             await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
+            await acceptInspection(4, inspectorAddress);
+            await advanceBlock(sintropArgs.blocksToExpireAcceptedInspection);
+
+            await requestInspection(regenerator5Address);
+            await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
           });
 
           it("should return error message", async () => {
-            await expect(acceptInspection(4, inspectorAddress)).to.be.revertedWith("Only 3 giveUps allowed");
+            await expect(acceptInspection(5, inspectorAddress)).to.be.revertedWith("Only 3 giveUps allowed");
           });
         });
 


### PR DESCRIPTION
PR to solve the issue 11 of the audit. 

The function isInspectorValid was updated to <= instead of only < to maintain the semantics of the text and allow 3 giveUps.

