### PR TITLE
5_medium_block_invitationDenied

### DIFF
--- a/contracts/CommunityRules.sol
+++ b/contracts/CommunityRules.sol
@@ -18,6 +18,9 @@ contract CommunityRules is Callable {
   /// @notice Minimum number of users allowed for a specific type before proportionality rules apply.
   uint16 private constant MINIMUM_REGISTERED_USERS_QUANTITY = 5;
 
+  /// @notice The maximum allowed amount of invalidated invited users.
+  uint16 private constant MAX_INVITER_PENALTIES = 5;
+
   /// @notice The number of blocks an invitation is delayed for Supporters.
   uint32 public constant SUPPORTER_INVITATION_DELAY_BLOCKS = 150;
 
@@ -224,6 +227,8 @@ contract CommunityRules is Callable {
     require(userType != CommunityTypes.UserType.UNDEFINED, "Invalid user type"); // Must selected the appropriate userType
     require(_registrationProportionalityAllowed(userType), "Proportionality invalid"); // Vacancies according to the number of regenerators
     require(_invitedTypeOnRegister(addr, userType), "Invalid invitation"); // Only with valid invitation
+    require(!isDenied(invitations[addr].inviter), "Inviter denied"); // Inviter cannot be denied
+    require(inviterPenalties[invitations[addr].inviter] < MAX_INVITER_PENALTIES, "Inviter with too many penalties"); // Inviter cannot exceed penalties
 
     users[addr] = userType;
     usersCount++;

--- a/test/CommunityRules.test.js
+++ b/test/CommunityRules.test.js
@@ -27,6 +27,14 @@ describe("CommunityRules", function () {
     return await instance.connect(from).addDelation(denouncedAddress, "title", "testimony");
   };
 
+  const addInviterPenalty = async (address, from) => {
+    return await instance.connect(from).addInviterPenalty(address);
+  };
+
+  const setToDenied = async (address, from) => {
+    return await instance.connect(from).setToDenied(address);
+  };
+
   beforeEach(async function () {
     [owner, user1Address, user2Address, user3Address, user4Address, user5Address, user6Address, user7Address] =
       await ethers.getSigners();
@@ -80,6 +88,41 @@ describe("CommunityRules", function () {
           await addUser(user1Address, userTypes.Regenerator, owner);
 
           await expect(addUser(user1Address, userTypes.Regenerator, owner)).to.be.revertedWith("User already exists");
+        });
+      });
+
+      context("when the inviter has been denied", () => {
+        beforeEach(async () => {
+          await addInvitation(owner, user2Address, userTypes.Activist, owner);
+          await addUser(user2Address, userTypes.Activist, owner);
+
+          await addInvitation(user2Address, user1Address, userTypes.Regenerator, owner);
+          await setToDenied(user2Address, owner);
+        });
+
+        it("should revert the addUser transaction for the invitee", async () => {
+          await expect(addUser(user1Address, userTypes.Regenerator, owner)).to.be.revertedWith("Inviter denied");
+        });
+      });
+
+      context("when the inviter exceeded maxInviter penalties", () => {
+        beforeEach(async () => {
+          await addInvitation(owner, user2Address, userTypes.Activist, owner);
+          await addUser(user2Address, userTypes.Activist, owner);
+
+          await addInvitation(user2Address, user1Address, userTypes.Regenerator, owner);
+
+          await addInviterPenalty(user2Address, owner);
+          await addInviterPenalty(user2Address, owner);
+          await addInviterPenalty(user2Address, owner);
+          await addInviterPenalty(user2Address, owner);
+          await addInviterPenalty(user2Address, owner);
+        });
+
+        it("should revert the addUser transaction for the invitee", async () => {
+          await expect(addUser(user1Address, userTypes.Regenerator, owner)).to.be.revertedWith(
+            "Inviter with too many penalties"
+          );
         });
       });
 
@@ -741,7 +784,7 @@ describe("CommunityRules", function () {
         await addUser(user1Address, userTypes.Regenerator, owner);
       });
 
-      it("", async () => {
+      it("should return error", async () => {
         await expect(communityRules.connect(user1Address).setToDenied(user1Address)).to.be.revertedWith(
           "Not allowed caller"
         );


### PR DESCRIPTION
PR to solve the issue 5 "Any type of user can accept invitation from denied users".

A require check was added to the addUser function at CommunityRules.sol to block registration of invited wallets by a denied inviter. Now, if a inviter gets denied, all invitations previously made from that user are not valid anymore.

To increase security, besides the isDenied check was added another require at addUser function to block registration from inviters that have exceeded the max inviter penalties