### PR TITLE
7_newExpiredInspections

### DIFF
--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -215,7 +215,11 @@ contract InspectionRules is Ownable, ReentrancyGuard {
     require(inspection.id >= 1, "Inspection do not exist");
     require(alreadyHaveInspectionAccepted(), "Already accepted");
     require(!inspectorInspected[msg.sender][inspection.regenerator], "Already inspected");
-    require(inspection.status == InspectionStatus.OPEN, "Inspection must be OPEN");
+    require(
+      inspection.status == InspectionStatus.OPEN ||
+        (inspection.status == InspectionStatus.ACCEPTED && _isInspectionExpired(inspection)),
+      "Inspection must be OPEN or EXPIRED"
+    );
     require(acceptInspectionDelayBlocksPassed(inspection), "Wait delay blocks");
     require(beforeAcceptHaveSecurityBlocksToVote(), "Wait until next era");
     require(inspectorRules.canAcceptInspection(msg.sender), "Wait to accept");
@@ -452,6 +456,15 @@ contract InspectionRules is Ownable, ReentrancyGuard {
     inspectorRules.removePoolLevels(inspection.inspector, false);
 
     emit InspectionInvalidated(inspection.id, inspection.inspector, inspection.regenerator, block.number);
+  }
+
+  /**
+   * @dev Checks if a previously accepted inspection has expired.
+   * @param inspection The inspection to check.
+   * @return bool True if the inspection is expired, false otherwise.
+   */
+  function _isInspectionExpired(Inspection storage inspection) private view returns (bool) {
+    return inspection.acceptedAt > 0 && (block.number > inspection.acceptedAt + blocksToExpireAcceptedInspection);
   }
 
   // --- View functions ---

--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -198,7 +198,7 @@ contract InspectionRules is Ownable, ReentrancyGuard {
    * - The `inspectionId` must correspond to an existing inspection.
    * - The inspector must not already have an inspection `ACCEPTED` that is not yet `INSPECTED` or `INVALIDATED` or `EXPIRED`.
    * - The inspector must not have previously inspected this specific regenerator.
-   * - The inspection's status must be `OPEN`.
+   * - The inspection's status must be `OPEN` or `EXPIRED`.
    * - The `acceptInspectionDelayBlocks` must have passed since the inspection was created.
    * - The system must not be within the `securityBlocksToValidation` window before an era ends.
    * - The inspector must adhere to `inspectorRules.canAcceptInspection` (delay from last realized inspection).

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -633,7 +633,32 @@ describe("InspectionRules", () => {
             });
 
             it("should return error message", async () => {
-              await expect(acceptInspection(1, inspector2Address)).to.be.revertedWith("Inspection must be OPEN");
+              await expect(acceptInspection(1, inspector2Address)).to.be.revertedWith(
+                "Inspection must be OPEN or EXPIRED"
+              );
+            });
+          });
+
+          context("when inspection is EXPIRED", () => {
+            beforeEach(async () => {
+              await advanceBlock(sintropArgs.acceptInspectionDelayBlocks);
+              await addInvitation(owner, inspector2Address, userTypes.Inspector, owner);
+              await acceptInspection(1, inspectorAddress);
+              await addInspector("Inspector B", inspector2Address);
+              await advanceBlock(sintropArgs.blocksToExpireAcceptedInspection);
+              await acceptInspection(1, inspector2Address);
+            });
+
+            it("should allow other inspector to accept expired inspection", async () => {
+              const inspection = await instance.getInspection(1);
+              expect(inspection.inspector).to.equal(inspector2Address);
+            });
+
+            it("should allow second inspector to realize the inspection", async () => {
+              await realizeInspection(1, "", treesResultValue, biodiversityResultValue, inspector2Address);
+
+              const inspection = await instance.getInspection(1);
+              expect(inspection.status).to.equal(STATUS.inspected);
             });
           });
 


### PR DESCRIPTION
PR to solve the issue 7 that Unexecuted Inspections may Block Regenerator Rewards.

A new function isInspectionExpired() was introduced to check if an existing inspection was expired. Then, the require inspection.STATUS == OPEN was incremented with the logic to check and allow other inspectors to accept the same inspection again, solving the reported issue.