### PR TITLE
2_zeroScore_Inspections

### DIFF
--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -274,8 +274,11 @@ contract InspectionRules is Ownable, ReentrancyGuard {
 
     _afterRealizeInspection(inspection);
 
-    inspectionsTreesImpact += treesResult;
-    inspectionsBiodiversityImpact += biodiversityResult;
+    if (inspection.regenerationScore > 0) {
+      inspectionsTreesImpact += treesResult;
+      inspectionsBiodiversityImpact += biodiversityResult;
+    }
+
     inspectorInspected[msg.sender][inspection.regenerator] = true;
     realizedInspectionsCount++;
 
@@ -420,7 +423,7 @@ contract InspectionRules is Ownable, ReentrancyGuard {
 
     activistRules.addInspectorLevel(
       inspectorAddress,
-      inspectorRules.afterRealizeInspection(inspectorAddress, inspection.id)
+      inspectorRules.afterRealizeInspection(inspectorAddress, inspection.regenerationScore, inspection.id)
     );
 
     regeneratorInspections[regeneratorAddress].push(inspection.id);

--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -239,7 +239,7 @@ contract InspectionRules is Ownable, ReentrancyGuard {
    * @notice Inspectors must evaluate the amount of trees and species of the regeneration area.
    * How many trees, palm trees and other plants over 1m high and 3cm in diameter there is in the regenerating area? Justify your answer in the report.
    * How many different species of those plants/trees were found? Each different species is equivalent to one unity and only trees and plants managed or planted by the regenerator should be counted. Justify your answer in the report.
-   * Max result of 200.000 trees and 300 biodiversity.
+   * Max result of trees by area and 300 biodiversity.
    * @param inspectionId The id of the inspection to be realized.
    * @param proofPhotos The string of a photo with the regenerator or the string of a document with the proofPhoto with the regenerator and other area photos.
    * @param justificationReport The justification and report of the result found.

--- a/contracts/InspectorRules.sol
+++ b/contracts/InspectorRules.sol
@@ -196,15 +196,22 @@ contract InspectorRules is Callable, ReentrancyGuard {
    * This decrements give-ups and increments total inspections.
    * @notice This function is called by the InspectionRules contract after an inspection is realized.
    * @param addr The inspector's wallet address.
+   * @param score The inspection regenerationScore.
+   * @param inspectionId The inspection unique ID.
    * @return uint256 The updated total number of inspections completed by the inspector.
    */
   function afterRealizeInspection(
     address addr,
+    uint32 score,
     uint64 inspectionId
   ) external mustBeAllowedCaller mustBeContractCall(inspectionRulesAddress) nonReentrant returns (uint256) {
     _decreaseGiveUps(addr);
 
-    return _incrementInspections(addr, inspectionId);
+    if (score > 0) {
+      return _incrementInspections(addr, inspectionId);
+    }
+
+    return inspectors[addr].totalInspections;
   }
 
   /**

--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -364,7 +364,13 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
 
     processedInspections[inspectionId] = true;
 
-    uint256 totalInspections = _incrementInspections(addr);
+    uint256 totalInspections;
+
+    if (score > 0) {
+      totalInspections = _incrementInspections(addr);
+    } else {
+      totalInspections = regenerators[addr].totalInspections;
+    }
 
     _setRegenerationScore(addr, score, inspectionId);
 

--- a/contracts/interfaces/IInspectorRules.sol
+++ b/contracts/interfaces/IInspectorRules.sol
@@ -35,9 +35,11 @@ interface IInspectorRules {
    * @notice A hook to be called after an inspector successfully completes an inspection.
    * @dev This function likely updates the inspector's counters and returns their new level or score.
    * @param inspector The address of the inspector who completed the inspection.
+   * @param score The regenerationScore of the inspection.
+   * @param inspectionId The inspection unique ID.
    * @return The new calculated level for the inspector.
    */
-  function afterRealizeInspection(address inspector, uint64 inspectionId) external returns (uint256);
+  function afterRealizeInspection(address inspector, uint32 score, uint64 inspectionId) external returns (uint256);
 
   /**
    * @dev Function to deny inspectors.

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -823,8 +823,8 @@ describe("InspectionRules", () => {
                     beforeEach(async () => {
                       await regeneratorRules.setContractCall(owner, owner);
 
-                      await regeneratorRules.connect(owner).afterRealizeInspection(regeneratorAddress, 0, 2);
-                      await regeneratorRules.connect(owner).afterRealizeInspection(regeneratorAddress, 0, 3);
+                      await regeneratorRules.connect(owner).afterRealizeInspection(regeneratorAddress, 1, 2);
+                      await regeneratorRules.connect(owner).afterRealizeInspection(regeneratorAddress, 1, 3);
 
                       await regeneratorRules.setContractCall(instance.target, validationRules.target);
 
@@ -851,8 +851,8 @@ describe("InspectionRules", () => {
                       await inspectorRules.connect(owner).afterAcceptInspection(inspectorAddress, 1);
                       await inspectorRules.connect(owner).afterAcceptInspection(inspectorAddress, 1);
 
-                      await inspectorRules.connect(owner).afterRealizeInspection(inspectorAddress, 1);
-                      await inspectorRules.connect(owner).afterRealizeInspection(inspectorAddress, 1);
+                      await inspectorRules.connect(owner).afterRealizeInspection(inspectorAddress, 1, 1);
+                      await inspectorRules.connect(owner).afterRealizeInspection(inspectorAddress, 1, 1);
 
                       await inspectorRules.setContractCall(instance.target);
 
@@ -877,14 +877,14 @@ describe("InspectionRules", () => {
                       await regeneratorRules.setContractCall(owner, owner);
                       await inspectorRules.setContractCall(owner, owner);
 
-                      await regeneratorRules.connect(owner).afterRealizeInspection(regeneratorAddress, 0, 5);
-                      await regeneratorRules.connect(owner).afterRealizeInspection(regeneratorAddress, 0, 2);
+                      await regeneratorRules.connect(owner).afterRealizeInspection(regeneratorAddress, 1, 5);
+                      await regeneratorRules.connect(owner).afterRealizeInspection(regeneratorAddress, 1, 2);
 
                       await inspectorRules.connect(owner).afterAcceptInspection(inspectorAddress, 3);
                       await inspectorRules.connect(owner).afterAcceptInspection(inspectorAddress, 4);
 
-                      await inspectorRules.connect(owner).afterRealizeInspection(inspectorAddress, 3);
-                      await inspectorRules.connect(owner).afterRealizeInspection(inspectorAddress, 4);
+                      await inspectorRules.connect(owner).afterRealizeInspection(inspectorAddress, 1, 3);
+                      await inspectorRules.connect(owner).afterRealizeInspection(inspectorAddress, 1, 4);
 
                       await regeneratorRules.setContractCall(instance.target, validationRules.target);
                       await inspectorRules.setContractCall(instance.target);

--- a/test/InspectorRules.test.js
+++ b/test/InspectorRules.test.js
@@ -134,6 +134,21 @@ describe("InspectorRules", () => {
 
   describe("#afterRealizeInspection", () => {
     context("with allowed caller", () => {
+      context("when score is set to zero", () => {
+        beforeEach(async () => {
+          await addInspector("Inspector A", inspe1Address);
+          await instance.setContractCall(owner, owner);
+          await instance.afterAcceptInspection(inspe1Address, 1);
+          await instance.afterRealizeInspection(inspe1Address, 0, 1);
+        });
+
+        it("should not increment inspector inspection count", async () => {
+          const inspector = await instance.getInspector(inspe1Address);
+
+          expect(inspector.totalInspections).to.equal(0);
+        });
+      });
+
       describe(".decreaseGiveUps", () => {
         beforeEach(async () => {
           await addInspector("Inspector A", inspe1Address);
@@ -142,7 +157,7 @@ describe("InspectorRules", () => {
 
           await instance.afterAcceptInspection(inspe1Address, 1);
           await instance.afterAcceptInspection(inspe1Address, 1);
-          await instance.afterRealizeInspection(inspe1Address, 1);
+          await instance.afterRealizeInspection(inspe1Address, 1, 1);
         });
 
         context("must decreaseGiveUps", () => {
@@ -159,7 +174,7 @@ describe("InspectorRules", () => {
           await addInspector("Inspector A", inspe1Address);
           await instance.setContractCall(owner, owner);
           await instance.afterAcceptInspection(inspe1Address, 1);
-          await instance.afterRealizeInspection(inspe1Address, 1);
+          await instance.afterRealizeInspection(inspe1Address, 1, 1);
         });
 
         context("when do not reached minimum inspections", () => {
@@ -180,8 +195,8 @@ describe("InspectorRules", () => {
               await instance.afterAcceptInspection(inspe1Address, 1);
               await instance.afterAcceptInspection(inspe1Address, 1);
 
-              await instance.afterRealizeInspection(inspe1Address, 1);
-              await instance.afterRealizeInspection(inspe1Address, 1);
+              await instance.afterRealizeInspection(inspe1Address, 1, 1);
+              await instance.afterRealizeInspection(inspe1Address, 1, 1);
             });
 
             it("should add 1 level to pool", async () => {
@@ -203,7 +218,7 @@ describe("InspectorRules", () => {
     context("without allowed caller", async () => {
       it("should return error when", async () => {
         await addInspector("Inspector A", inspe1Address);
-        await expect(instance.connect(inspe1Address).afterRealizeInspection(inspe1Address, 1)).to.be.revertedWith(
+        await expect(instance.connect(inspe1Address).afterRealizeInspection(inspe1Address, 1, 1)).to.be.revertedWith(
           "Not allowed caller"
         );
       });
@@ -268,8 +283,8 @@ describe("InspectorRules", () => {
         await instance.afterAcceptInspection(inspe1Address, 1);
         await instance.afterAcceptInspection(inspe1Address, 1);
 
-        await instance.afterRealizeInspection(inspe1Address, 1);
-        await instance.afterRealizeInspection(inspe1Address, 1);
+        await instance.afterRealizeInspection(inspe1Address, 1, 1);
+        await instance.afterRealizeInspection(inspe1Address, 1, 1);
       });
 
       context("when have less then 3 inspections", () => {
@@ -281,7 +296,7 @@ describe("InspectorRules", () => {
       context("when inspector is in era 1 and current era is 1", () => {
         it("should return error", async () => {
           await instance.afterAcceptInspection(inspe1Address, 1);
-          await instance.afterRealizeInspection(inspe1Address, 1);
+          await instance.afterRealizeInspection(inspe1Address, 1, 1);
 
           await expect(instance.connect(inspe1Address).withdraw()).to.be.revertedWith(
             "Not eligible to withdraw for this era"
@@ -293,7 +308,7 @@ describe("InspectorRules", () => {
         context("with one inspection", () => {
           beforeEach(async () => {
             await instance.afterAcceptInspection(inspe1Address, 1);
-            await instance.afterRealizeInspection(inspe1Address, 1);
+            await instance.afterRealizeInspection(inspe1Address, 1, 1);
 
             await advanceBlock(args.blocksPerEra);
 
@@ -312,15 +327,15 @@ describe("InspectorRules", () => {
           beforeEach(async () => {
             await addInspector("Inspector B", inspe2Address);
             await instance.afterAcceptInspection(inspe1Address, 1);
-            await instance.afterRealizeInspection(inspe1Address, 1);
+            await instance.afterRealizeInspection(inspe1Address, 1, 1);
 
             await instance.afterAcceptInspection(inspe2Address, 1);
             await instance.afterAcceptInspection(inspe2Address, 1);
             await instance.afterAcceptInspection(inspe2Address, 1);
 
-            await instance.afterRealizeInspection(inspe2Address, 1);
-            await instance.afterRealizeInspection(inspe2Address, 1);
-            await instance.afterRealizeInspection(inspe2Address, 2);
+            await instance.afterRealizeInspection(inspe2Address, 1, 1);
+            await instance.afterRealizeInspection(inspe2Address, 1, 1);
+            await instance.afterRealizeInspection(inspe2Address, 1, 2);
 
             await advanceBlock(args.blocksPerEra);
 

--- a/test/RegeneratorRules.test.js
+++ b/test/RegeneratorRules.test.js
@@ -372,6 +372,17 @@ describe("RegeneratorRules", () => {
       await addRegenerator("Regenerator A", prod1Address);
     });
 
+    context("when score is set to zero", () => {
+      beforeEach(async () => {
+        await instance.afterRealizeInspection(prod1Address, 0, 2);
+      });
+
+      it("should not increment regenerator inspection count", async () => {
+        const regenerator = await instance.getRegenerator(prod1Address);
+        expect(regenerator.totalInspections).to.equal(0);
+      });
+    });
+
     context("with allowed user", () => {
       describe(".setRegenerationScore", () => {
         context("when dont have regenerators sustainable", () => {
@@ -489,7 +500,7 @@ describe("RegeneratorRules", () => {
 
       describe(".incrementInspections", () => {
         beforeEach(async () => {
-          await instance.afterRealizeInspection(prod1Address, 0, 1);
+          await instance.afterRealizeInspection(prod1Address, 1, 1);
         });
 
         it("incrementInspections", async () => {
@@ -520,16 +531,16 @@ describe("RegeneratorRules", () => {
         context("when regenerator have minimum inspections", () => {
           context("when levels in era is 100", () => {
             beforeEach(async () => {
-              await instance.afterRealizeInspection(prod1Address, 0, 1);
-              await instance.afterRealizeInspection(prod1Address, 0, 2);
-              await instance.afterRealizeInspection(prod1Address, 0, 3);
+              await instance.afterRealizeInspection(prod1Address, 1, 1);
+              await instance.afterRealizeInspection(prod1Address, 1, 2);
+              await instance.afterRealizeInspection(prod1Address, 1, 3);
             });
 
             context("when regenerator have regenerationScore 50", () => {
               beforeEach(async () => {
-                await instance.afterRealizeInspection(prod2Address, 0, 4);
-                await instance.afterRealizeInspection(prod2Address, 0, 5);
-                await instance.afterRealizeInspection(prod2Address, 0, 6);
+                await instance.afterRealizeInspection(prod2Address, 1, 4);
+                await instance.afterRealizeInspection(prod2Address, 1, 5);
+                await instance.afterRealizeInspection(prod2Address, 1, 6);
 
                 await instance.afterRealizeInspection(prod1Address, 50, 7);
                 await instance.afterRealizeInspection(prod2Address, 50, 8);
@@ -596,9 +607,9 @@ describe("RegeneratorRules", () => {
 
       context("when cant approve #blockable", () => {
         beforeEach(async () => {
-          await instance.afterRealizeInspection(prod1Address, 0, 1);
-          await instance.afterRealizeInspection(prod1Address, 0, 2);
-          await instance.afterRealizeInspection(prod1Address, 0, 3);
+          await instance.afterRealizeInspection(prod1Address, 1, 1);
+          await instance.afterRealizeInspection(prod1Address, 1, 2);
+          await instance.afterRealizeInspection(prod1Address, 1, 3);
         });
 
         it("should return error message", async () => {

--- a/test/ValidationRules.test.js
+++ b/test/ValidationRules.test.js
@@ -711,9 +711,9 @@ describe("ValidationRules", () => {
                 await inspectorRules.afterAcceptInspection(inspector1Address, 1);
                 await inspectorRules.afterAcceptInspection(inspector1Address, 1);
 
-                await inspectorRules.afterRealizeInspection(inspector1Address, 1);
-                await inspectorRules.afterRealizeInspection(inspector1Address, 1);
-                await inspectorRules.afterRealizeInspection(inspector1Address, 1);
+                await inspectorRules.afterRealizeInspection(inspector1Address, 1, 1);
+                await inspectorRules.afterRealizeInspection(inspector1Address, 1, 1);
+                await inspectorRules.afterRealizeInspection(inspector1Address, 1, 1);
 
                 await instance.connect(user1Address).addUserValidation(inspector1Address, "my justification");
                 await instance.connect(user2Address).addUserValidation(inspector1Address, "my justification");


### PR DESCRIPTION
PR to solve the issue 2 of the audit report "Inspectors Are Unfairly Penalized When Detecting Invalid Regenerators".

This problem was solved by introducing a check to only count as a realized inspection and increment the ecological counters if the regeneration score is positive. Also, was added a check to only add pool level and increment inspections count to both regenerators and inspectors if score is not zero.

We will encourage inspectors to realize the inspection passing 0 as value and with his description/delation of the problem faced on the report. So with this update, 0 score inspection will not afect the token ecological backing, will not increase level and inspections count, will not increase the inspector giveUp count and may not be penalized if well justified at the report.

This way, the inspector don't even need to create a delation, the the zero inspection with the justification for the invalid regenerator. No giveUps, no penalty, if validators agree with the justification.