### PR TITLE
3_pastEra_impact

### DIFF
--- a/contracts/InspectionRules.sol
+++ b/contracts/InspectionRules.sol
@@ -9,7 +9,7 @@ import { IValidationRules } from "./interfaces/IValidationRules.sol";
 import { IActivistRules } from "./interfaces/IActivistRules.sol";
 import { ICommunityRules } from "./interfaces/ICommunityRules.sol";
 import { IVoteRules } from "./interfaces/IVoteRules.sol";
-import { InspectionStatus, Inspection, ContractsDependency } from "./types/InspectionTypes.sol";
+import { InspectionStatus, Inspection, ContractsDependency, EraImpact } from "./types/InspectionTypes.sol";
 import { Regenerator } from "./types/RegeneratorTypes.sol";
 import { Inspector } from "./types/InspectorTypes.sol";
 import { CommunityTypes } from "./types/CommunityTypes.sol";
@@ -63,17 +63,21 @@ contract InspectionRules is Ownable, ReentrancyGuard {
   /// @notice Valid inspections count (inspections not invalidated).
   uint64 public inspectionsCount;
 
-  /// @notice Realized inspections count (inspections that have been completed and submitted).
-  uint64 public realizedInspectionsCount;
-
   /// @notice Total inspections count, including open, accepted, realized, and invalidated ones.
   uint64 public inspectionsTotalCount;
 
-  /// @notice Sum of all valid inspections' trees impact.
+  /// @notice Realized inspections count (inspections that have been completed and submitted).
+  uint256 public realizedInspectionsCount;
+
+  /// @notice Sum of all valid inspections' trees impact from all past settled eras.
   uint256 public inspectionsTreesImpact;
 
-  /// @notice Sum of all valid inspections' biodiversity impact.
+  /// @notice Sum of all valid inspections' biodiversity impact from all past settled eras.
   uint256 public inspectionsBiodiversityImpact;
+
+  /// @notice The total count of regenerators who are considered "impact regenerators",
+  /// have reached the minimum of one inspection validated.
+  uint256 public totalImpactRegenerators;
 
   /// @notice Tracks inspection IDs that have already been invalidated.
   mapping(uint64 => bool) public inspectionPenalized;
@@ -110,6 +114,12 @@ contract InspectionRules is Ownable, ReentrancyGuard {
 
   /// @notice Tracks which validator has voted on which inspection to prevent duplicate votes.
   mapping(address => mapping(uint256 => bool)) private validatorInspectionsValidations;
+
+  /// @notice Tracks the impact generated within each specific era.
+  mapping(uint256 => EraImpact) public impactPerEra;
+
+  /// @notice Tracks the number of the last era that impact has been set.
+  uint256 public lastSettledEra;
 
   // --- Constructor ---
 
@@ -183,6 +193,9 @@ contract InspectionRules is Ownable, ReentrancyGuard {
 
     // Update regenerator's state in RegeneratorRules.
     _afterRequestInspection();
+
+    // Update era impact.
+    _setEraImpact();
   }
 
   /**
@@ -240,6 +253,9 @@ contract InspectionRules is Ownable, ReentrancyGuard {
    * How many trees, palm trees and other plants over 1m high and 3cm in diameter there is in the regenerating area? Justify your answer in the report.
    * How many different species of those plants/trees were found? Each different species is equivalent to one unity and only trees and plants managed or planted by the regenerator should be counted. Justify your answer in the report.
    * Max result of 200.000 trees and 300 biodiversity.
+   * Zero score means invalid inspection.
+   * NOTE: If the inspector finds something suspicous about the inspected regenerator, such as invalid area, suspicious of fake account, or if the Regenerator is not
+   * findable, inspectors are encourage to realize passing 0 as values with his justification at the report to avoid being penalized.
    * @param inspectionId The id of the inspection to be realized.
    * @param proofPhotos The string of a photo with the regenerator or the string of a document with the proofPhoto with the regenerator and other area photos.
    * @param justificationReport The justification and report of the result found.
@@ -274,10 +290,15 @@ contract InspectionRules is Ownable, ReentrancyGuard {
 
     _afterRealizeInspection(inspection);
 
-    inspectionsTreesImpact += treesResult;
-    inspectionsBiodiversityImpact += biodiversityResult;
+    // Only count inspections that have a positive impact towards the global metrics.
+    if (inspection.regenerationScore > 0) {
+      uint256 era = inspection.inspectedAtEra;
+      impactPerEra[era].trees += treesResult;
+      impactPerEra[era].biodiversity += biodiversityResult;
+      impactPerEra[era].realizedInspections++;
+    }
+
     inspectorInspected[msg.sender][inspection.regenerator] = true;
-    realizedInspectionsCount++;
 
     emit InspectionRealized(
       inspectionId,
@@ -434,12 +455,12 @@ contract InspectionRules is Ownable, ReentrancyGuard {
    * @param inspection A reference to the `Inspection` struct being invalidated.
    */
   function _invalidateInspection(Inspection storage inspection) private {
-    // Decrement global impact metrics.
-    inspectionsTreesImpact -= inspection.treesResult;
-    inspectionsBiodiversityImpact -= inspection.biodiversityResult;
+    // Decrement era impact metrics.
+    impactPerEra[inspection.inspectedAtEra].trees -= inspection.treesResult;
+    impactPerEra[inspection.inspectedAtEra].biodiversity -= inspection.biodiversityResult;
+    impactPerEra[inspection.inspectedAtEra].realizedInspections--;
 
     inspectionsCount--; // Decrement valid inspections count
-    realizedInspectionsCount--; // Decrement realized inspections count
 
     // Update inspection status
     inspection.status = InspectionStatus.INVALIDATED;
@@ -452,6 +473,24 @@ contract InspectionRules is Ownable, ReentrancyGuard {
     inspectorRules.removePoolLevels(inspection.inspector, false);
 
     emit InspectionInvalidated(inspection.id, inspection.inspector, inspection.regenerator, block.number);
+  }
+
+  /**
+   * @dev Sets the impact of a pending era to the global counter.
+   */
+  function _setEraImpact() private {
+    uint256 nextEraToSet = lastSettledEra + 1;
+
+    if (nextEraToSet < regeneratorRules.poolCurrentEra()) {
+      EraImpact storage eraImpact = impactPerEra[nextEraToSet];
+
+      inspectionsTreesImpact += eraImpact.trees;
+      inspectionsBiodiversityImpact += eraImpact.biodiversity;
+      realizedInspectionsCount += eraImpact.realizedInspections;
+      totalImpactRegenerators += regeneratorRules.newCertificationRegenerators(nextEraToSet);
+      // Update the lastSetlledEra to the era just settled.
+      lastSettledEra = nextEraToSet;
+    }
   }
 
   // --- View functions ---

--- a/contracts/RegenerationCreditImpact.sol
+++ b/contracts/RegenerationCreditImpact.sol
@@ -66,7 +66,7 @@ contract RegenerationCreditImpact {
     if (inspectionRules.realizedInspectionsCount() == 0) return 0;
 
     return
-      (inspectionRules.inspectionsTreesImpact() * regeneratorRules.totalImpactRegenerators()) /
+      (inspectionRules.inspectionsTreesImpact() * inspectionRules.totalImpactRegenerators()) /
       inspectionRules.realizedInspectionsCount();
   }
 
@@ -88,7 +88,7 @@ contract RegenerationCreditImpact {
     if (inspectionRules.realizedInspectionsCount() == 0) return 0;
 
     return
-      (inspectionRules.inspectionsBiodiversityImpact() * regeneratorRules.totalImpactRegenerators()) /
+      (inspectionRules.inspectionsBiodiversityImpact() * inspectionRules.totalImpactRegenerators()) /
       inspectionRules.realizedInspectionsCount();
   }
 

--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -77,6 +77,10 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
   /// @notice Tracks which inspection IDs have already been processed to prevent replay attacks.
   mapping(uint64 => bool) private processedInspections;
 
+  /// @notice The number of regenerators that have started the certification process on each era,
+  /// and have reached the minimum of one inspection.
+  mapping(uint256 => uint256) public newCertificationRegenerators;
+
   /// @notice Tracks if a coordinate point have already been processed.
   mapping(bytes32 => bool) seenCoordinates;
 
@@ -100,10 +104,6 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
 
   /// @notice The address of the `InspectionRules` contract.
   address private validationRulesAddress;
-
-  /// @notice The number of regenerators that have started the certification process on each era,
-  /// and have reached the minimum of one inspection.
-  mapping(uint256 => uint256) public newCertificationRegenerators;
 
   // --- Constructor ---
 

--- a/contracts/RegeneratorRules.sol
+++ b/contracts/RegeneratorRules.sol
@@ -91,10 +91,6 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
   /// @notice The specific `UserType` enumeration value for a Regenerator user.
   CommunityTypes.UserType private constant USER_TYPE = CommunityTypes.UserType.REGENERATOR;
 
-  /// @notice The total count of regenerators who are considered "impact regenerators"
-  /// (have achieved the minimum of three inspections.
-  uint256 public totalImpactRegenerators;
-
   /// @notice The grand total sum of all regeneration area (in square meters [m²])
   /// managed by all registered regenerators in the system.
   uint256 public regenerationArea;
@@ -104,6 +100,10 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
 
   /// @notice The address of the `InspectionRules` contract.
   address private validationRulesAddress;
+
+  /// @notice The number of regenerators that have started the certification process on each era,
+  /// and have reached the minimum of one inspection.
+  mapping(uint256 => uint256) public newCertificationRegenerators;
 
   // --- Constructor ---
 
@@ -314,7 +314,10 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
     require(totalInspections > 0, "totalInspections invalid");
 
     if (totalInspections == 1) {
-      totalImpactRegenerators--;
+      uint256 era = poolCurrentEra();
+      if (newCertificationRegenerators[era] > 0) {
+        newCertificationRegenerators[era]--;
+      }
       impactRegenerators[addr] = false;
     }
 
@@ -522,7 +525,8 @@ contract RegeneratorRules is Callable, ReentrancyGuard {
     // Mark as impact regenerator.
     if (!impactRegenerators[addr]) {
       impactRegenerators[addr] = true;
-      totalImpactRegenerators++;
+      uint256 era = poolCurrentEra();
+      newCertificationRegenerators[era]++;
     }
 
     return regenerator.totalInspections;

--- a/contracts/interfaces/IInspectionRules.sol
+++ b/contracts/interfaces/IInspectionRules.sol
@@ -26,4 +26,10 @@ interface IInspectionRules {
    * @return The total biodiversity impact value.
    */
   function inspectionsBiodiversityImpact() external view returns (uint256);
+
+  /**
+   * @notice Returns the total number of impact regenerators, users with at least one inspection validated.
+   * @return The total of regenerators on the certification process.
+   */
+  function totalImpactRegenerators() external view returns (uint256);
 }

--- a/contracts/interfaces/IRegeneratorRules.sol
+++ b/contracts/interfaces/IRegeneratorRules.sol
@@ -67,10 +67,11 @@ interface IRegeneratorRules {
   function removePoolLevels(address user) external;
 
   /**
-   * @notice Returns the total number of impact regenerators, users that completed 3 inspections.
-   * @return The total impact regenerators.
+   * @notice Returns the number of new regenerators that achieved impact status in a specific era.
+   * @param era The era number to query.
+   * @return uint256 The count of new impact regenerators for that era.
    */
-  function totalImpactRegenerators() external view returns (uint256);
+  function newCertificationRegenerators(uint256 era) external view returns (uint256);
 
   /**
    * @notice Returns the total area under regeneration across all regenerators.

--- a/contracts/types/InspectionTypes.sol
+++ b/contracts/types/InspectionTypes.sol
@@ -57,3 +57,16 @@ struct ContractsDependency {
   address activistRulesAddress;
   address voteRulesAddress;
 }
+
+/**
+ * @notice Tracks the inspection impact of an Era.
+ * @dev This struct is used to register the impact of all inspection of an Era.
+ * @param trees Trees count.
+ * @param biodiversity Biodiversity count.
+ * @param realizedInspections Era realizedInspections count.
+ */
+struct EraImpact {
+  uint256 trees;
+  uint256 biodiversity;
+  uint256 realizedInspections;
+}

--- a/test/InspectionRules.test.js
+++ b/test/InspectionRules.test.js
@@ -917,16 +917,16 @@ describe("InspectionRules", () => {
                     expect(inspection.status).to.equal(STATUS.inspected);
                   });
 
-                  it("should set inspectionsTreesImpact", async () => {
+                  it("should not set inspectionsTreesImpact", async () => {
                     const inspectionsTreesImpact = await instance.inspectionsTreesImpact();
 
-                    expect(inspectionsTreesImpact).to.equal(10);
+                    expect(inspectionsTreesImpact).to.equal(0);
                   });
 
-                  it("should set inspectionsBiodiversityImpact", async () => {
+                  it("should not set inspectionsBiodiversityImpact", async () => {
                     const inspectionsBiodiversityImpact = await instance.inspectionsBiodiversityImpact();
 
-                    expect(inspectionsBiodiversityImpact).to.equal(10);
+                    expect(inspectionsBiodiversityImpact).to.equal(0);
                   });
 
                   it("populate inspection inspectedAt", async () => {
@@ -966,10 +966,18 @@ describe("InspectionRules", () => {
                     expect(inspector.totalInspections).to.equal(1);
                   });
 
-                  it("should increment realizedInspectionsCount", async () => {
+                  it("should not increment realizedInspectionsCount", async () => {
                     const realizedInspectionsCount = await instance.realizedInspectionsCount();
 
-                    expect(realizedInspectionsCount).to.equal(1);
+                    expect(realizedInspectionsCount).to.equal(0);
+                  });
+
+                  it("should increment era impactPerEra", async () => {
+                    const impactPerEra = await instance.impactPerEra(1);
+
+                    expect(impactPerEra.trees).to.equal(10);
+                    expect(impactPerEra.biodiversity).to.equal(10);
+                    expect(impactPerEra.realizedInspections).to.equal(1);
                   });
                 });
 

--- a/test/RegenerationCreditImpact.test.js
+++ b/test/RegenerationCreditImpact.test.js
@@ -5,7 +5,7 @@ const { userTypes } = require("./shared/user_types");
 const { advanceBlock } = require("./shared/advance_block");
 
 describe("RegenerationCreditImpact", () => {
-  let instance, inspectionRules, invitationRules, regeneratorRules, inspectorRules, regenerationCredit;
+  let instance, inspectionRules, invitationRules, regeneratorRules, inspectorRules, regenerationCredit, validationPool;
   let owner,
     regeneratorAddress,
     regenerator2Address,
@@ -24,7 +24,7 @@ describe("RegenerationCreditImpact", () => {
     const coordinatesParams = _coordinates.length > 0 ? _coordinates : coordinates();
     await regeneratorRules
       .connect(from)
-      .addRegenerator(1000, name, "projectDescription", "photoURL", coordinatesParams);
+      .addRegenerator(2500, name, "projectDescription", "photoURL", coordinatesParams);
   };
 
   const addInspector = async (name, from) => {
@@ -56,6 +56,12 @@ describe("RegenerationCreditImpact", () => {
     const proofPhoto = "proofPhoto";
 
     await inspectionRules.connect(from).realizeInspection(id, proofPhoto, report, treesResult, biodiversityResult);
+  };
+
+  const nextEraRequestInspection = async (regeneratorAddress) => {
+    await advanceBlock(500);
+
+    await inspectionRules.connect(regeneratorAddress).requestInspection();
   };
 
   beforeEach(async () => {
@@ -158,6 +164,8 @@ describe("RegenerationCreditImpact", () => {
               treesIndicatorValue = 10;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returnstotalTreesImpact equal 10", async () => {
@@ -172,6 +180,8 @@ describe("RegenerationCreditImpact", () => {
               treesIndicatorValue = 32;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returnstotalTreesImpact equal 32", async () => {
@@ -230,6 +240,8 @@ describe("RegenerationCreditImpact", () => {
 
             treesIndicatorValue = 32;
             await realizeInspection(5, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector5Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returnstotalTreesImpact equal 174", async () => {
@@ -269,6 +281,8 @@ describe("RegenerationCreditImpact", () => {
 
             treesIndicatorValue = 100;
             await realizeInspection(3, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector3Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returnstotalTreesImpact equal 88", async () => {
@@ -374,6 +388,8 @@ describe("RegenerationCreditImpact", () => {
               treesIndicatorValue = 10;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returnstotalCarbonImpact equal 1000000", async () => {
@@ -388,6 +404,8 @@ describe("RegenerationCreditImpact", () => {
               treesIndicatorValue = 32;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returnstotalCarbonImpact equal 3200000", async () => {
@@ -446,6 +464,8 @@ describe("RegenerationCreditImpact", () => {
 
             treesIndicatorValue = 32;
             await realizeInspection(5, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector5Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returnstotalCarbonImpact equal 17400000", async () => {
@@ -485,6 +505,8 @@ describe("RegenerationCreditImpact", () => {
 
             treesIndicatorValue = 100;
             await realizeInspection(3, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector3Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returnstotalCarbonImpact equal 8800000", async () => {
@@ -550,6 +572,8 @@ describe("RegenerationCreditImpact", () => {
               biodiversityIndicatorValue = 10;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returns totalBiodiversityImpact equal 10", async () => {
@@ -564,6 +588,8 @@ describe("RegenerationCreditImpact", () => {
               biodiversityIndicatorValue = 32;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returns totalBiodiversityImpact equal 32", async () => {
@@ -622,6 +648,8 @@ describe("RegenerationCreditImpact", () => {
 
             biodiversityIndicatorValue = 32;
             await realizeInspection(5, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector5Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returns totalBiodiversityImpact equal 174", async () => {
@@ -661,6 +689,8 @@ describe("RegenerationCreditImpact", () => {
 
             biodiversityIndicatorValue = 100;
             await realizeInspection(3, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector3Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returns totalBiodiversityImpact equal 88", async () => {
@@ -724,10 +754,10 @@ describe("RegenerationCreditImpact", () => {
 
     context("when have two regenerators", () => {
       context("when all regenerators are valids", async () => {
-        it("totalAreaImpact must be 2000", async () => {
+        it("totalAreaImpact must be 5000", async () => {
           const totalAreaImpact = await instance.totalAreaImpact();
 
-          expect(totalAreaImpact).to.equal(2000);
+          expect(totalAreaImpact).to.equal(5000);
         });
       });
 
@@ -737,10 +767,10 @@ describe("RegenerationCreditImpact", () => {
           await regeneratorRules.removePoolLevels(regenerator2Address);
         });
 
-        it("totalAreaImpact must be 1000", async () => {
+        it("totalAreaImpact must be 2500", async () => {
           const totalAreaImpact = await instance.totalAreaImpact();
 
-          expect(totalAreaImpact).to.equal(1000);
+          expect(totalAreaImpact).to.equal(2500);
         });
       });
     });
@@ -804,6 +834,8 @@ describe("RegenerationCreditImpact", () => {
                 treesIndicatorValue = 10;
 
                 await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+                await nextEraRequestInspection(regeneratorAddress);
               });
 
               it("must returns treesPerToken equal 6666666666", async () => {
@@ -821,6 +853,8 @@ describe("RegenerationCreditImpact", () => {
                 treesIndicatorValue = 10;
 
                 await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+                await nextEraRequestInspection(regeneratorAddress);
               });
 
               it("must returns treesPerToken equal 11111111111", async () => {
@@ -836,6 +870,8 @@ describe("RegenerationCreditImpact", () => {
               treesIndicatorValue = 32;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returnstotalTreesImpact equal 21333333333", async () => {
@@ -894,6 +930,8 @@ describe("RegenerationCreditImpact", () => {
 
             treesIndicatorValue = 32;
             await realizeInspection(5, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector5Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returns treesPerToken equal 116000000000", async () => {
@@ -933,6 +971,8 @@ describe("RegenerationCreditImpact", () => {
 
             treesIndicatorValue = 100;
             await realizeInspection(3, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector3Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returns treesPerToken equal 58666666666", async () => {
@@ -1043,6 +1083,8 @@ describe("RegenerationCreditImpact", () => {
                 treesIndicatorValue = 10;
 
                 await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+                await nextEraRequestInspection(regeneratorAddress);
               });
 
               it("must returns carbonPerToken equal 666666666666666", async () => {
@@ -1060,6 +1102,8 @@ describe("RegenerationCreditImpact", () => {
                 treesIndicatorValue = 10;
 
                 await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+                await nextEraRequestInspection(regeneratorAddress);
               });
 
               it("must returns carbonPerToken equal 1111111111111111", async () => {
@@ -1075,6 +1119,8 @@ describe("RegenerationCreditImpact", () => {
               treesIndicatorValue = 32;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returnstotalTreesImpact equal 2133333333333333", async () => {
@@ -1133,6 +1179,8 @@ describe("RegenerationCreditImpact", () => {
 
             treesIndicatorValue = 32;
             await realizeInspection(5, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector5Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returns carbonPerToken equal 11600000000000000", async () => {
@@ -1172,6 +1220,8 @@ describe("RegenerationCreditImpact", () => {
 
             treesIndicatorValue = 100;
             await realizeInspection(3, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector3Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returns carbonPerToken equal 5866666666666666", async () => {
@@ -1238,6 +1288,8 @@ describe("RegenerationCreditImpact", () => {
                 biodiversityIndicatorValue = 10;
 
                 await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+                await nextEraRequestInspection(regeneratorAddress);
               });
 
               it("must returns biodiversityPerToken equal 6666666666", async () => {
@@ -1255,6 +1307,8 @@ describe("RegenerationCreditImpact", () => {
                 biodiversityIndicatorValue = 10;
 
                 await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+                await nextEraRequestInspection(regeneratorAddress);
               });
 
               it("must returns biodiversityPerToken equal 11111111111", async () => {
@@ -1270,6 +1324,8 @@ describe("RegenerationCreditImpact", () => {
               biodiversityIndicatorValue = 32;
 
               await realizeInspection(1, "report", treesIndicatorValue, biodiversityIndicatorValue, inspectorAddress);
+
+              await nextEraRequestInspection(regeneratorAddress);
             });
 
             it("must returns biodiversityPerToken equal 21333333333", async () => {
@@ -1328,6 +1384,8 @@ describe("RegenerationCreditImpact", () => {
 
             biodiversityIndicatorValue = 32;
             await realizeInspection(5, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector5Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returns biodiversityPerToken equal 116000000000", async () => {
@@ -1367,6 +1425,8 @@ describe("RegenerationCreditImpact", () => {
 
             biodiversityIndicatorValue = 100;
             await realizeInspection(3, "report", treesIndicatorValue, biodiversityIndicatorValue, inspector3Address);
+
+            await nextEraRequestInspection(regeneratorAddress);
           });
 
           it("must returns biodiversityPerToken equal 58666666666", async () => {
@@ -1431,10 +1491,10 @@ describe("RegenerationCreditImpact", () => {
     context("when have two regenerators", () => {
       context("when all regenerators are valids", async () => {
         context("when do not have tokens totalLocked_", () => {
-          it("areaPerToken must be 1333333333333", async () => {
+          it("areaPerToken must be 3333333333333", async () => {
             const areaPerToken = await instance.areaPerToken();
 
-            expect(areaPerToken).to.equal(1333333333333);
+            expect(areaPerToken).to.equal(3333333333333);
           });
         });
 
@@ -1444,10 +1504,10 @@ describe("RegenerationCreditImpact", () => {
             await regenerationCredit.addContractPool(owner, 300000000000000000000000000n);
           });
 
-          it("areaPerToken must be 2222222222222", async () => {
+          it("areaPerToken must be 5555555555555", async () => {
             const areaPerToken = await instance.areaPerToken();
 
-            expect(areaPerToken).to.equal(2222222222222);
+            expect(areaPerToken).to.equal(5555555555555);
           });
         });
       });
@@ -1458,10 +1518,10 @@ describe("RegenerationCreditImpact", () => {
           await regeneratorRules.removePoolLevels(regenerator2Address);
         });
 
-        it("areaPerToken must be 666666666666", async () => {
+        it("areaPerToken must be 1666666666666", async () => {
           const areaPerToken = await instance.areaPerToken();
 
-          expect(areaPerToken).to.equal(666666666666);
+          expect(areaPerToken).to.equal(1666666666666);
         });
       });
     });


### PR DESCRIPTION
PR to solve the issue 3 of the audit report "Inspectors Can Inflate Ecological Value to Profit from Token Sales ".

A struct impactEra and a mapping from era to impactEra was introduced. Now the impact calculation is realized by era. A setEraImpact function was added at the request inspection function to add the past era impact to the global metrics. So now the impact will be increased at the first requestInspection of each era, summing only the past impact to avoid the manipulation issue.

To avoid variables conflict, the logic to calculate the impact regenerators, users that are on the certification process was changed and now a mapping registers how many new impact regenerators started at each era.

